### PR TITLE
Handle deletion error in ask_and_store

### DIFF
--- a/handlers/common.py
+++ b/handlers/common.py
@@ -4,6 +4,7 @@ from aiogram import types
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State
+from aiogram.exceptions import TelegramBadRequest
 
 
 def get_main_menu() -> ReplyKeyboardMarkup:
@@ -37,7 +38,10 @@ async def ask_and_store(
     Затем переводит FSM в next_state.
     """
     # Удаляем сообщение пользователя
-    await message.delete()
+    try:
+        await message.delete()
+    except TelegramBadRequest:
+        pass
 
     # Удаляем предыдущий бот-вопрос
     data = await state.get_data()


### PR DESCRIPTION
## Summary
- handle `TelegramBadRequest` when deleting user message in `ask_and_store`

## Testing
- `python -m py_compile handlers/common.py`
- `python -m py_compile handlers/*.py`
- `python -m py_compile bot.py db.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_683ff7356274832baf20f28f61439268