### PR TITLE
Fix greeting comment typo

### DIFF
--- a/handlers/registration.py
+++ b/handlers/registration.py
@@ -26,7 +26,7 @@ async def cmd_start(message: types.Message, state: FSMContext):
     conn.close()
 
     if user:
-        # Привествуем возвращённого пользователя
+        # Приветствуем возвращённого пользователя
         name = user["name"]
         await message.answer(
             f"Добро пожаловать обратно, {name}!",


### PR DESCRIPTION
## Summary
- correct typo in registration handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683ff72d2eec832bb74a3de113933b1c