### PR TITLE
Add DB indexes and weight checks

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,4 @@
+class Config:
+    """Project-wide configuration constants."""
+    # Maximum allowed weight in kilograms for cargo and trucks
+    MAX_WEIGHT = 100000


### PR DESCRIPTION
## Summary
- add Config for global constants
- add weight check constraints and create indexes in `db.init_db`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400e3abd94832b81fe7a1875a20bb2