### PR TITLE
Add phone and weight validation utils with tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,12 @@ aiogram_types_module.Message = _DummyMessage
 sys.modules.setdefault("aiogram", aiogram_module)
 sys.modules.setdefault("aiogram.types", aiogram_types_module)
 
-from utils import parse_date, format_date_for_display
+from utils import (
+    parse_date,
+    format_date_for_display,
+    validate_weight,
+    validate_phone,
+)
 
 
 def test_parse_date_valid():
@@ -39,3 +44,27 @@ def test_format_date_for_display_with_time():
 
 def test_format_date_for_display_invalid():
     assert format_date_for_display("oops") == "oops"
+
+
+def test_validate_weight_valid():
+    assert validate_weight("15") == (True, 15)
+
+
+@pytest.mark.parametrize("val", ["0", "-1", "text", "1001"])
+def test_validate_weight_invalid(val):
+    ok, weight = validate_weight(val)
+    assert not ok
+    assert weight == 0
+
+
+def test_validate_phone_valid():
+    assert validate_phone("+79991234567")
+    assert validate_phone("79991234567")
+
+
+@pytest.mark.parametrize(
+    "phone",
+    ["12345", "+1234abc5678", "7999123456", "++79991234567"],
+)
+def test_validate_phone_invalid(phone):
+    assert not validate_phone(phone)

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@
 
 from contextlib import contextmanager
 from datetime import datetime
+import re
 
 from aiogram import types
 from db import get_connection
@@ -64,3 +65,26 @@ def format_date_for_display(iso_date: str) -> str:
         return dt.strftime("%d.%m.%Y")
     except Exception:
         return iso_date  # если парсинг не удался, возвращаем как есть
+
+
+def validate_weight(weight_str: str) -> tuple[bool, int]:
+    """Validate and convert weight string to integer tons.
+
+    The weight must be a positive integer between 1 and 1000 (tons).
+    Returns a tuple ``(is_valid, value)`` where ``value`` is 0 when invalid.
+    """
+    try:
+        weight = int(weight_str.strip())
+    except (TypeError, ValueError):
+        return False, 0
+    if 1 <= weight <= 1000:
+        return True, weight
+    return False, 0
+
+
+_PHONE_RE = re.compile(r"^\+?\d{11}$")
+
+
+def validate_phone(phone: str) -> bool:
+    """Return ``True`` if the phone number matches ``+?\d{11}``."""
+    return bool(_PHONE_RE.fullmatch(phone.strip()))


### PR DESCRIPTION
## Summary
- add `validate_weight` and `validate_phone` helpers
- test phone and weight validators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400f615180832b8e27eabc1033b5f1