### PR TITLE
Implement search results pagination

### DIFF
--- a/handlers/cargo.py
+++ b/handlers/cargo.py
@@ -7,7 +7,7 @@ from aiogram.fsm.state import State, StatesGroup
 from datetime import datetime
 
 from db import get_connection
-from .common import get_main_menu, ask_and_store
+from .common import get_main_menu, ask_and_store, show_search_results
 from utils import parse_date, get_current_user_id, format_date_for_display
 
 
@@ -455,17 +455,7 @@ async def filter_date_to(message: types.Message, state: FSMContext):
     if not rows:
         await message.answer("📬 По вашему запросу ничего не найдено.", reply_markup=get_main_menu())
     else:
-        text = "📋 Найденные грузы:\n\n"
-        for r in rows:
-            date_disp = format_date_for_display(r["date_from"])
-            text += (
-                f"ID: {r['id']}\n"
-                f"Владелец: {r['name']}\n"
-                f"{r['city_from']}, {r['region_from']} → {r['city_to']}, {r['region_to']}\n"
-                f"Дата отправления: {date_disp}\n"
-                f"Вес: {r['weight']} т, Кузов: {r['body_type']}\n\n"
-            )
-        await message.answer(text, reply_markup=get_main_menu())
+        await show_search_results(message, rows)
 
     await state.clear()
 

--- a/handlers/common.py
+++ b/handlers/common.py
@@ -1,10 +1,18 @@
 # handlers/common.py
 
 from aiogram import types
-from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+from aiogram.types import (
+    ReplyKeyboardMarkup,
+    KeyboardButton,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+)
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State
 from aiogram.exceptions import TelegramBadRequest
+import math
+
+from utils import format_date_for_display
 
 
 def get_main_menu() -> ReplyKeyboardMarkup:
@@ -63,3 +71,51 @@ async def ask_and_store(
 
     # Переходим в следующий статус
     await state.set_state(next_state)
+
+
+async def show_search_results(message: types.Message, rows, page: int = 0, per_page: int = 5):
+    """Send paginated search results with optional navigation buttons."""
+    total = len(rows)
+    if total == 0:
+        await message.answer("📬 По вашему запросу ничего не найдено.", reply_markup=get_main_menu())
+        return
+
+    start = page * per_page
+    end = start + per_page
+    page_rows = rows[start:end]
+
+    # Determine row type
+    is_cargo = "city_from" in page_rows[0].keys()
+    header = "\ud83d\udccb \u041d\u0430\u0439\u0434\u0435\u043d\u043d\u044b\u0435 \u0433\u0440\u0443\u0437\u044b:\n\n" if is_cargo else "\ud83d\udccb \u041d\u0430\u0439\u0434\u0435\u043d\u043d\u044b\u0435 \u0422\u0421:\n\n"
+    text = header
+
+    for r in page_rows:
+        date_disp = format_date_for_display(r["date_from"])
+        if is_cargo:
+            text += (
+                f"ID: {r['id']}\n"
+                f"\u0412\u043b\u0430\u0434\u0435\u043b\u0435\u0446: {r['name']}\n"
+                f"{r['city_from']}, {r['region_from']} → {r['city_to']}, {r['region_to']}\n"
+                f"\u0414\u0430\u0442\u0430 \u043e\u0442\u043f\u0440\u0430\u0432\u043b\u0435\u043d\u0438\u044f: {date_disp}\n"
+                f"\u0412\u0435\u0441: {r['weight']} \u0442, \u041a\u0443\u0437\u043e\u0432: {r['body_type']}\n\n"
+            )
+        else:
+            text += (
+                f"ID: {r['id']}\n"
+                f"\u0412\u043b\u0430\u0434\u0435\u043b\u0435\u0446: {r['name']}\n"
+                f"{r['city']}, {r['region']}\n"
+                f"\u0414\u0430\u0442\u0430 \u0434\u043e\u0441\u0442\u0443\u043f\u043d\u043e: {date_disp}\n"
+                f"\u0413\u0440\u0443\u0437\u043e\u043f\u043e\u0434\u044a\u0451\u043c\u043d\u043e\u0441\u0442\u044c: {r['weight']} \u0442, \u041a\u0443\u0437\u043e\u0432: {r['body_type']}\n"
+                f"\u041d\u0430\u043f\u0440\u0430\u0432\u043b\u0435\u043d\u0438\u0435: {r['direction']}\n\n"
+            )
+
+    markup: types.InlineKeyboardMarkup | types.ReplyKeyboardMarkup | None = None
+    if total > per_page:
+        buttons = []
+        if page > 0:
+            buttons.append(InlineKeyboardButton(text="\u041d\u0430\u0437\u0430\u0434", callback_data=f"page:{page-1}"))
+        if end < total:
+            buttons.append(InlineKeyboardButton(text="\u0412\u043f\u0435\u0440\u0451\u0434", callback_data=f"page:{page+1}"))
+        markup = InlineKeyboardMarkup(inline_keyboard=[buttons])
+
+    await message.answer(text, reply_markup=markup or get_main_menu())

--- a/handlers/truck.py
+++ b/handlers/truck.py
@@ -8,7 +8,7 @@ from aiogram.fsm.state import State, StatesGroup
 from datetime import datetime
 
 from db import get_connection
-from .common import get_main_menu, ask_and_store
+from .common import get_main_menu, ask_and_store, show_search_results
 from utils import parse_date, get_current_user_id, format_date_for_display
 
 
@@ -387,18 +387,7 @@ async def filter_date_to_truck(message: types.Message, state: FSMContext):
     if not rows:
         await message.answer("📬 По вашему запросу ТС не найдено.", reply_markup=get_main_menu())
     else:
-        text = "📋 Найденные ТС:\n\n"
-        for r in rows:
-            date_disp = format_date_for_display(r["date_from"])
-            text += (
-                f"ID: {r['id']}\n"
-                f"Владелец: {r['name']}\n"
-                f"{r['city']}, {r['region']}\n"
-                f"Дата доступно: {date_disp}\n"
-                f"Грузоподъёмность: {r['weight']} т, Кузов: {r['body_type']}\n"
-                f"Направление: {r['direction']}\n\n"
-            )
-        await message.answer(text, reply_markup=get_main_menu())
+        await show_search_results(message, rows)
 
     await state.clear()
 


### PR DESCRIPTION
## Summary
- add `show_search_results` helper for paginated results
- use `show_search_results` in cargo and truck search handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400fcef2b4832bab6191a896267d79