### PR TITLE
Add logging helper and integrate actions

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -21,7 +21,8 @@ API_TOKEN = os.getenv("API_TOKEN")
 
 async def main():
     try:
-        logging.basicConfig(level=logging.INFO)
+        if not logging.getLogger().hasHandlers():
+            logging.basicConfig(level=logging.INFO)
 
         # Инициализация БД
         from db import init_db

--- a/handlers/cargo.py
+++ b/handlers/cargo.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from db import get_connection
 from .common import get_main_menu, ask_and_store
-from utils import parse_date, get_current_user_id, format_date_for_display
+from utils import parse_date, get_current_user_id, format_date_for_display, log_user_action
 
 
 class CargoAddStates(StatesGroup):
@@ -254,6 +254,7 @@ async def process_comment(message: types.Message, state: FSMContext):
         conn.commit()
 
     await message.answer("✅ Груз успешно добавлен!", reply_markup=get_main_menu())
+    log_user_action(user_id, "cargo_added")
     await state.clear()
 
 # ========== СЦЕНАРИЙ: ПОИСК ГРУЗА С КНОПКАМИ ==========
@@ -411,6 +412,7 @@ async def filter_date_to(message: types.Message, state: FSMContext):
         await state.update_data(filter_date_to="нет")
 
     data = await state.get_data()
+    user_id = await get_current_user_id(message)
     fc_from = data.get("filter_city_from", "")
     fc_to = data.get("filter_city_to", "")
     fd_from = data.get("filter_date_from", "")
@@ -467,6 +469,7 @@ async def filter_date_to(message: types.Message, state: FSMContext):
             )
         await message.answer(text, reply_markup=get_main_menu())
 
+    log_user_action(user_id, "cargo_search", f"results={len(rows)}")
     await state.clear()
 
 def register_cargo_handlers(dp: Dispatcher):

--- a/handlers/registration.py
+++ b/handlers/registration.py
@@ -9,6 +9,7 @@ from aiogram.types import ReplyKeyboardRemove, ContentType
 from db import get_connection
 from datetime import datetime
 from .common import get_main_menu
+from utils import get_current_user_id, log_user_action
 
 
 class Registration(StatesGroup):
@@ -91,6 +92,9 @@ async def process_phone(message: types.Message, state: FSMContext):
         f"Регистрация завершена! Приятно познакомиться, {name}.",
         reply_markup=get_main_menu()
     )
+    user_id = await get_current_user_id(message)
+    if user_id:
+        log_user_action(user_id, "registration")
     await state.clear()
 
 

--- a/handlers/truck.py
+++ b/handlers/truck.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from db import get_connection
 from .common import get_main_menu, ask_and_store
-from utils import parse_date, get_current_user_id, format_date_for_display
+from utils import parse_date, get_current_user_id, format_date_for_display, log_user_action
 
 
 class TruckAddStates(StatesGroup):
@@ -237,6 +237,7 @@ async def process_truck_comment(message: types.Message, state: FSMContext):
         conn.commit()
 
     await message.answer("✅ ТС успешно добавлено!", reply_markup=get_main_menu())
+    log_user_action(user_id, "truck_added")
     await state.clear()
 
 # ========== СЦЕНАРИЙ: ПОИСК ТС С КНОПКАМИ ==========
@@ -347,6 +348,7 @@ async def filter_date_to_truck(message: types.Message, state: FSMContext):
         await state.update_data(filter_date_to="нет")
 
     data = await state.get_data()
+    user_id = await get_current_user_id(message)
     fc = data.get("filter_city", "")
     fd_from = data.get("filter_date_from", "")
     fd_to = data.get("filter_date_to", "")
@@ -400,6 +402,7 @@ async def filter_date_to_truck(message: types.Message, state: FSMContext):
             )
         await message.answer(text, reply_markup=get_main_menu())
 
+    log_user_action(user_id, "truck_search", f"results={len(rows)}")
     await state.clear()
 
 def register_truck_handlers(dp: Dispatcher):

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@
 
 from contextlib import contextmanager
 from datetime import datetime
+import logging
 
 from aiogram import types
 from db import get_connection
@@ -64,3 +65,11 @@ def format_date_for_display(iso_date: str) -> str:
         return dt.strftime("%d.%m.%Y")
     except Exception:
         return iso_date  # если парсинг не удался, возвращаем как есть
+
+
+def log_user_action(user_id: int, action: str, details: str = "") -> None:
+    """Log a user action for auditing purposes."""
+    if details:
+        logging.info("user=%s action=%s details=%s", user_id, action, details)
+    else:
+        logging.info("user=%s action=%s", user_id, action)


### PR DESCRIPTION
## Summary
- add `log_user_action` helper for unified logging
- initialize logging in `bot.py` only when needed
- log registration, cargo/truck additions and searches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400ff8969c832baa60da25b8a9a8ab