### PR TITLE
Add cached city queries and invalidation

### DIFF
--- a/handlers/cargo.py
+++ b/handlers/cargo.py
@@ -8,7 +8,14 @@ from datetime import datetime
 
 from db import get_connection
 from .common import get_main_menu, ask_and_store
-from utils import parse_date, get_current_user_id, format_date_for_display
+from utils import (
+    parse_date,
+    get_current_user_id,
+    format_date_for_display,
+    get_unique_cities_from,
+    get_unique_cities_to,
+    clear_city_cache,
+)
 
 
 class CargoAddStates(StatesGroup):
@@ -253,6 +260,8 @@ async def process_comment(message: types.Message, state: FSMContext):
         )
         conn.commit()
 
+    clear_city_cache()
+
     await message.answer("✅ Груз успешно добавлен!", reply_markup=get_main_menu())
     await state.clear()
 
@@ -271,15 +280,8 @@ async def cmd_start_find_cargo(message: types.Message, state: FSMContext):
     # Удаляем сообщение-инициатор (нажатие "🔍 Найти груз")
     await message.delete()
 
-    # Получаем список уникальных городов отправления из таблицы cargo
-    conn = get_connection()
-    cursor = conn.cursor()
-    cursor.execute("SELECT DISTINCT city_from FROM cargo WHERE city_from IS NOT NULL")
-    rows = cursor.fetchall()
-    conn.close()
-
-    cities = [r["city_from"] for r in rows if r["city_from"].strip()]
-    cities.sort(key=lambda x: x.lower())  # отсортируем по алфавиту
+    # Получаем список уникальных городов отправления
+    cities = get_unique_cities_from()
 
     # Строим клавиатуру: каждая строка — один город, и внизу кнопка "Все"
     kb_buttons = [[types.KeyboardButton(text=city)] for city in cities]
@@ -318,16 +320,8 @@ async def filter_city_from(message: types.Message, state: FSMContext):
         except Exception:
             pass
 
-    # Теперь предлагаем выбрать город назначения аналогично
-    # Получаем уникальные города назначения из cargo
-    conn = get_connection()
-    cursor = conn.cursor()
-    cursor.execute("SELECT DISTINCT city_to FROM cargo WHERE city_to IS NOT NULL")
-    rows = cursor.fetchall()
-    conn.close()
-
-    to_cities = [r["city_to"] for r in rows if r["city_to"].strip()]
-    to_cities.sort(key=lambda x: x.lower())
+    # Теперь предлагаем выбрать город назначения
+    to_cities = get_unique_cities_to()
 
     kb_buttons = [[types.KeyboardButton(text=city)] for city in to_cities]
     kb_buttons.append([types.KeyboardButton(text="Все")])

--- a/handlers/truck.py
+++ b/handlers/truck.py
@@ -9,7 +9,13 @@ from datetime import datetime
 
 from db import get_connection
 from .common import get_main_menu, ask_and_store
-from utils import parse_date, get_current_user_id, format_date_for_display
+from utils import (
+    parse_date,
+    get_current_user_id,
+    format_date_for_display,
+    get_unique_truck_cities,
+    clear_city_cache,
+)
 
 
 class TruckAddStates(StatesGroup):
@@ -236,6 +242,8 @@ async def process_truck_comment(message: types.Message, state: FSMContext):
         )
         conn.commit()
 
+    clear_city_cache()
+
     await message.answer("✅ ТС успешно добавлено!", reply_markup=get_main_menu())
     await state.clear()
 
@@ -254,15 +262,8 @@ async def cmd_start_find_trucks(message: types.Message, state: FSMContext):
     # Удаляем сообщение-инициатор (нажатие "🔍 Найти ТС")
     await message.delete()
 
-    # Получаем уникальные города стоянки из таблицы trucks
-    conn = get_connection()
-    cursor = conn.cursor()
-    cursor.execute("SELECT DISTINCT city FROM trucks WHERE city IS NOT NULL")
-    rows = cursor.fetchall()
-    conn.close()
-
-    cities = [r["city"] for r in rows if r["city"].strip()]
-    cities.sort(key=lambda x: x.lower())
+    # Получаем уникальные города стоянки
+    cities = get_unique_truck_cities()
 
     kb_buttons = [[types.KeyboardButton(text=city)] for city in cities]
     kb_buttons.append([types.KeyboardButton(text="Все")])


### PR DESCRIPTION
## Summary
- cache unique city lists in `utils.py`
- use cached helpers in cargo/truck search handlers
- clear caches after inserting cargo/truck

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684010295c34832bbc864339c3c15f53