### PR TITLE
Display progress in add flows

### DIFF
--- a/handlers/cargo.py
+++ b/handlers/cargo.py
@@ -8,7 +8,12 @@ from datetime import datetime
 
 from db import get_connection
 from .common import get_main_menu, ask_and_store
-from utils import parse_date, get_current_user_id, format_date_for_display
+from utils import (
+    parse_date,
+    get_current_user_id,
+    format_date_for_display,
+    show_progress,
+)
 
 
 class CargoAddStates(StatesGroup):
@@ -40,7 +45,11 @@ async def cmd_start_add_cargo(message: types.Message, state: FSMContext):
         return
 
     # Удаляем любое предыдущее сообщение (если требуется)
-    await message.answer("📦 Начнём добавление груза.\nОткуда (город):", reply_markup=types.ReplyKeyboardRemove())
+    await message.answer(
+        "📦 Начнём добавление груза.\nОткуда (город):",
+        reply_markup=types.ReplyKeyboardRemove(),
+    )
+    await show_progress(message, 1, 10)
     await state.set_state(CargoAddStates.city_from)
 
 
@@ -53,6 +62,7 @@ async def process_city_from(message: types.Message, state: FSMContext):
         "Регион отправления:",
         CargoAddStates.region_from
     )
+    await show_progress(message, 2, 10)
 
 
 async def process_region_from(message: types.Message, state: FSMContext):
@@ -63,6 +73,7 @@ async def process_region_from(message: types.Message, state: FSMContext):
         "Куда (город):",
         CargoAddStates.city_to
     )
+    await show_progress(message, 3, 10)
 
 
 async def process_city_to(message: types.Message, state: FSMContext):
@@ -73,6 +84,7 @@ async def process_city_to(message: types.Message, state: FSMContext):
         "Регион назначения:",
         CargoAddStates.region_to
     )
+    await show_progress(message, 4, 10)
 
 
 async def process_region_to(message: types.Message, state: FSMContext):
@@ -83,6 +95,7 @@ async def process_region_to(message: types.Message, state: FSMContext):
         "Дата отправления (ДД.MM.ГГГГ):",
         CargoAddStates.date_from
     )
+    await show_progress(message, 5, 10)
 
 
 async def process_date_from(message: types.Message, state: FSMContext):
@@ -99,6 +112,7 @@ async def process_date_from(message: types.Message, state: FSMContext):
         "Дата прибытия (ДД.MM.ГГГГ):",
         CargoAddStates.date_to
     )
+    await show_progress(message, 6, 10)
 
 
 async def process_date_to(message: types.Message, state: FSMContext):
@@ -124,6 +138,7 @@ async def process_date_to(message: types.Message, state: FSMContext):
         "Вес (в тоннах, цифрой):",
         CargoAddStates.weight
     )
+    await show_progress(message, 7, 10)
 
 
 async def process_weight(message: types.Message, state: FSMContext):
@@ -153,6 +168,7 @@ async def process_weight(message: types.Message, state: FSMContext):
         CargoAddStates.body_type,
         reply_markup=kb
     )
+    await show_progress(message, 8, 10)
 
 
 async def process_body_type(message: types.Message, state: FSMContext):
@@ -178,6 +194,7 @@ async def process_body_type(message: types.Message, state: FSMContext):
         CargoAddStates.is_local,
         reply_markup=kb
     )
+    await show_progress(message, 9, 10)
 
 
 async def process_is_local(message: types.Message, state: FSMContext):
@@ -194,6 +211,7 @@ async def process_is_local(message: types.Message, state: FSMContext):
         "Добавь комментарий (или напиши 'нет'):",
         CargoAddStates.comment
     )
+    await show_progress(message, 10, 10)
 
 
 async def process_comment(message: types.Message, state: FSMContext):

--- a/handlers/truck.py
+++ b/handlers/truck.py
@@ -9,7 +9,12 @@ from datetime import datetime
 
 from db import get_connection
 from .common import get_main_menu, ask_and_store
-from utils import parse_date, get_current_user_id, format_date_for_display
+from utils import (
+    parse_date,
+    get_current_user_id,
+    format_date_for_display,
+    show_progress,
+)
 
 
 class TruckAddStates(StatesGroup):
@@ -38,7 +43,11 @@ async def cmd_start_add_truck(message: types.Message, state: FSMContext):
         await message.answer("Сначала зарегистрируйся через /start.")
         return
 
-    await message.answer("🚛 Начнём добавление ТС.\nВ каком городе стоит ТС?", reply_markup=types.ReplyKeyboardRemove())
+    await message.answer(
+        "🚛 Начнём добавление ТС.\nВ каком городе стоит ТС?",
+        reply_markup=types.ReplyKeyboardRemove(),
+    )
+    await show_progress(message, 1, 9)
     await state.set_state(TruckAddStates.city)
 
 
@@ -50,6 +59,7 @@ async def process_city(message: types.Message, state: FSMContext):
         "Регион стоянки:",
         TruckAddStates.region
     )
+    await show_progress(message, 2, 9)
 
 
 async def process_region(message: types.Message, state: FSMContext):
@@ -60,6 +70,7 @@ async def process_region(message: types.Message, state: FSMContext):
         "Дата доступности (с) (ДД.MM.ГГГГ):",
         TruckAddStates.date_from
     )
+    await show_progress(message, 3, 9)
 
 
 async def process_date_from(message: types.Message, state: FSMContext):
@@ -76,6 +87,7 @@ async def process_date_from(message: types.Message, state: FSMContext):
         "Дата доступности (по) (ДД.MM.ГГГГ):",
         TruckAddStates.date_to
     )
+    await show_progress(message, 4, 9)
 
 
 async def process_date_to(message: types.Message, state: FSMContext):
@@ -101,6 +113,7 @@ async def process_date_to(message: types.Message, state: FSMContext):
         "Грузоподъёмность (в тоннах):",
         TruckAddStates.weight
     )
+    await show_progress(message, 5, 9)
 
 
 async def process_weight(message: types.Message, state: FSMContext):
@@ -130,6 +143,7 @@ async def process_weight(message: types.Message, state: FSMContext):
         TruckAddStates.body_type,
         reply_markup=kb
     )
+    await show_progress(message, 6, 9)
 
 
 async def process_body_type(message: types.Message, state: FSMContext):
@@ -155,6 +169,7 @@ async def process_body_type(message: types.Message, state: FSMContext):
         TruckAddStates.direction,
         reply_markup=kb
     )
+    await show_progress(message, 7, 9)
 
 
 async def process_direction(message: types.Message, state: FSMContext):
@@ -170,6 +185,7 @@ async def process_direction(message: types.Message, state: FSMContext):
         "Перечисли через запятую регионы, где готов ехать (или 'нет'):",
         TruckAddStates.route_regions
     )
+    await show_progress(message, 8, 9)
 
 
 async def process_route_regions(message: types.Message, state: FSMContext):
@@ -182,6 +198,7 @@ async def process_route_regions(message: types.Message, state: FSMContext):
         "Добавь комментарий (или напиши 'нет'):",
         TruckAddStates.comment
     )
+    await show_progress(message, 9, 9)
 
 
 async def process_truck_comment(message: types.Message, state: FSMContext):

--- a/utils.py
+++ b/utils.py
@@ -64,3 +64,14 @@ def format_date_for_display(iso_date: str) -> str:
         return dt.strftime("%d.%m.%Y")
     except Exception:
         return iso_date  # если парсинг не удался, возвращаем как есть
+
+
+async def show_progress(message: types.Message, step: int, total: int) -> None:
+    """Отображает прогресс в виде текстовой шкалы."""
+    if total <= 0:
+        return
+
+    bar_length = 10
+    filled = int(bar_length * step / total)
+    bar = "█" * filled + "░" * (bar_length - filled)
+    await message.answer(f"Прогресс: {bar} {step}/{total}")


### PR DESCRIPTION
## Summary
- add `show_progress` helper for textual progress bars
- display progress during cargo creation workflow
- display progress during truck creation workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684010405920832bb1ebfc96cd036917