### PR TITLE
Implement bot statistics metrics

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -27,6 +27,15 @@ async def main():
         from db import init_db
         init_db()
 
+        # Логируем базовую статистику
+        from metrics import get_bot_statistics
+        total_users, new_users = get_bot_statistics()
+        logging.info(
+            "Bot stats: total_users=%s, registered_last_24h=%s",
+            total_users,
+            new_users,
+        )
+
         # Создаём бота и диспетчер
         bot = Bot(token=API_TOKEN)
         dp = Dispatcher(storage=MemoryStorage())

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,17 @@
+# metrics.py
+
+from utils import db_cursor
+
+
+def get_bot_statistics():
+    """Return total number of users and users registered in the last 24 hours."""
+    with db_cursor() as cursor:
+        cursor.execute("SELECT COUNT(*) FROM users")
+        total_users = cursor.fetchone()[0]
+
+        cursor.execute(
+            "SELECT COUNT(*) FROM users WHERE datetime(created_at) >= datetime('now', '-1 day')"
+        )
+        new_users = cursor.fetchone()[0]
+
+    return total_users, new_users

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import tempfile
+import types
+
+# Ensure project root is on sys.path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+aiogram_module = types.ModuleType("aiogram")
+aiogram_types_module = types.ModuleType("aiogram.types")
+aiogram_module.types = aiogram_types_module
+class _DummyMessage:
+    pass
+aiogram_types_module.Message = _DummyMessage
+sys.modules.setdefault("aiogram", aiogram_module)
+sys.modules.setdefault("aiogram.types", aiogram_types_module)
+
+import sqlite3
+
+import db
+from metrics import get_bot_statistics
+
+
+def setup_temp_db(monkeypatch):
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    monkeypatch.setattr(db, "DB_PATH", tmp.name)
+    db.init_db()
+    return tmp.name
+
+
+def test_get_bot_statistics(monkeypatch):
+    db_path = setup_temp_db(monkeypatch)
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    # user registered long ago
+    cur.execute(
+        "INSERT INTO users (telegram_id, name, city, phone, created_at) VALUES (1, 'old', 'c', 'p', '2020-01-01')"
+    )
+    # user registered now
+    cur.execute(
+        "INSERT INTO users (telegram_id, name, city, phone, created_at) VALUES (2, 'new', 'c', 'p', datetime('now'))"
+    )
+    conn.commit()
+    conn.close()
+
+    total, new = get_bot_statistics()
+    assert total == 2
+    assert new == 1


### PR DESCRIPTION
## Summary
- implement `metrics.get_bot_statistics` for counting users
- log metrics at startup
- add regression tests for `get_bot_statistics`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840107fad90832ba376916ba1687f9a