### PR TITLE
Add cancel and help handlers

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,8 @@ from handlers import (
     register_user_handlers,
     register_cargo_handlers,
     register_truck_handlers,
-    register_profile_handler
+    register_profile_handler,
+    register_common_handlers
 )
 
 load_dotenv()
@@ -36,6 +37,7 @@ async def main():
         register_cargo_handlers(dp)
         register_truck_handlers(dp)
         register_profile_handler(dp)
+        register_common_handlers(dp)
 
         # Запускаем поллинг
         await dp.start_polling(bot)

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -4,3 +4,4 @@ from .registration import register_user_handlers
 from .cargo import register_cargo_handlers
 from .truck import register_truck_handlers
 from .profile import register_profile_handler
+from .common import register_common_handlers

--- a/handlers/common.py
+++ b/handlers/common.py
@@ -1,7 +1,8 @@
 # handlers/common.py
 
-from aiogram import types
+from aiogram import types, Dispatcher
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State
 from aiogram.exceptions import TelegramBadRequest
@@ -63,3 +64,27 @@ async def ask_and_store(
 
     # Переходим в следующий статус
     await state.set_state(next_state)
+
+
+async def cmd_cancel(message: types.Message, state: FSMContext):
+    """Отмена текущего действия и возврат в главное меню."""
+    await state.clear()
+    await message.answer("Действие отменено.", reply_markup=get_main_menu())
+
+
+async def cmd_help(message: types.Message):
+    """Выводит справочное сообщение со списком команд."""
+    text = (
+        "Доступные команды:\n"
+        "/start - регистрация или главное меню\n"
+        "/help - показать эту справку\n"
+        "/cancel - отменить текущую операцию"
+    )
+    await message.answer(text)
+
+
+def register_common_handlers(dp: Dispatcher):
+    """Регистрация общих хендлеров."""
+    dp.message.register(cmd_cancel, Command(commands=["cancel"]))
+    dp.message.register(cmd_help, Command(commands=["help"]))
+


### PR DESCRIPTION
## Summary
- implement `/cancel` and `/help` command handlers
- expose new `register_common_handlers` and wire into dispatcher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401065d6cc832ba4761b6f31b61104