### PR TITLE
Fix DB_PATH override and add dotenv

### DIFF
--- a/db.py
+++ b/db.py
@@ -4,13 +4,15 @@ import sqlite3
 
 from config import Config
 
-from config import Config
+# Allow overriding the database path in tests
+DB_PATH: str = Config.DB_PATH
 
 # Always use path relative to this file so running the bot from any working
 # directory works correctly. Path is now defined in Config.
 
 def get_connection():
-    conn = sqlite3.connect(Config.DB_PATH)
+    """Return a new SQLite connection using :data:`DB_PATH`."""
+    conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
     return conn
 
@@ -77,4 +79,4 @@ def init_db():
 
 if __name__ == "__main__":
     init_db()
-    print("База данных инициализирована в", Config.DB_PATH)
+    print("База данных инициализирована в", DB_PATH)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 aiogram==3.20.0.post0
+python-dotenv


### PR DESCRIPTION
## Summary
- allow db.DB_PATH override for tests
- use DB_PATH in `get_connection`
- include python-dotenv in requirements

## Testing
- `pytest -q`
- `python bot.py` *(fails: Cannot connect to host api.telegram.org)*

------
https://chatgpt.com/codex/tasks/task_e_684028b921c4832b8fb5511ad2c6e3f1