### PR TITLE
Clean up imports and fix DB path handling

### DIFF
--- a/db.py
+++ b/db.py
@@ -4,13 +4,14 @@ import sqlite3
 
 from config import Config
 
-from config import Config
+# Database file path can be overridden in tests via monkeypatching
+DB_PATH = Config.DB_PATH
 
 # Always use path relative to this file so running the bot from any working
 # directory works correctly. Path is now defined in Config.
 
 def get_connection():
-    conn = sqlite3.connect(Config.DB_PATH)
+    conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
     return conn
 
@@ -77,4 +78,4 @@ def init_db():
 
 if __name__ == "__main__":
     init_db()
-    print("База данных инициализирована в", Config.DB_PATH)
+    print("База данных инициализирована в", DB_PATH)

--- a/handlers/common.py
+++ b/handlers/common.py
@@ -4,7 +4,6 @@
 from aiogram import types, Dispatcher
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from aiogram.filters import Command
-from aiogram import types
 from aiogram.types import (
     ReplyKeyboardMarkup,
     KeyboardButton,
@@ -15,7 +14,6 @@ from aiogram.types import (
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State
 from aiogram.exceptions import TelegramBadRequest
-import math
 
 from utils import format_date_for_display
 


### PR DESCRIPTION
## Summary
- remove duplicate aiogram types import and unused math module
- make DB path overridable for tests by using a `DB_PATH` constant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402a27b568832b89f62e172da0859a