### PR TITLE
Add location selection and update flows

### DIFF
--- a/locations.py
+++ b/locations.py
@@ -1,0 +1,17 @@
+"""Predefined regions and their cities for user selection."""
+
+REGION_TO_CITIES: dict[str, list[str]] = {
+    "Moscow Oblast": ["Moscow", "Khimki", "Podolsk"],
+    "Saint Petersburg Oblast": ["Saint Petersburg", "Pushkin", "Pavlovsk"],
+    "Novosibirsk Oblast": ["Novosibirsk", "Berdsk", "Iskitim"],
+}
+
+
+def get_regions() -> list[str]:
+    """Return the list of available regions."""
+    return list(REGION_TO_CITIES.keys())
+
+
+def get_cities(region: str) -> list[str]:
+    """Return the cities for the given region or empty list."""
+    return REGION_TO_CITIES.get(region, [])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,6 +23,7 @@ from utils import (
     validate_weight,
     validate_phone,
 )
+from locations import get_regions, get_cities
 
 
 def test_parse_date_valid():
@@ -68,3 +69,11 @@ def test_validate_phone_valid():
 )
 def test_validate_phone_invalid(phone):
     assert not validate_phone(phone)
+
+
+def test_locations_lists():
+    regions = get_regions()
+    assert regions, "regions list should not be empty"
+    for r in regions:
+        cities = get_cities(r)
+        assert cities, f"{r} should have cities"


### PR DESCRIPTION
## Summary
- add `locations.py` with predefined regions and cities
- update CargoAddStates and TruckAddStates flows to pick region first then city
- import new helpers in tests and check locations lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404320ad4c832b8ecf19738e024f55