### PR TITLE
Add paged location selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This Telegram bot allows users to register, add cargo and trucks, and search the
 - **Progress bar** when filling long forms.
 - **Weight validation** ensures values are between 1 and 1000 tons.
 - **Inline calendar** for selecting dates when adding or searching cargo and trucks.
+- **Paged location selection** when adding cargo or trucks using data from
+  `russia.json`.
 - **Common commands** `/help` and `/cancel`.
 
 ## Running the bot

--- a/handlers/common.py
+++ b/handlers/common.py
@@ -36,6 +36,25 @@ def get_main_menu() -> ReplyKeyboardMarkup:
     )
 
 
+def create_paged_keyboard(
+    items: list[str], has_prev: bool, has_next: bool
+) -> ReplyKeyboardMarkup:
+    """Return a reply keyboard with paging controls."""
+    rows = [[KeyboardButton(text=i)] for i in items]
+    nav_row: list[KeyboardButton] = []
+    if has_prev:
+        nav_row.append(KeyboardButton(text="Назад"))
+    if has_next:
+        nav_row.append(KeyboardButton(text="Вперёд"))
+    if nav_row:
+        rows.append(nav_row)
+    return ReplyKeyboardMarkup(
+        keyboard=rows,
+        resize_keyboard=True,
+        one_time_keyboard=True,
+    )
+
+
 async def ask_and_store(
     message: types.Message,
     state: FSMContext,

--- a/locations.py
+++ b/locations.py
@@ -1,17 +1,61 @@
-"""Predefined regions and their cities for user selection."""
+"""Utilities for obtaining Russian regions and cities."""
 
-REGION_TO_CITIES: dict[str, list[str]] = {
-    "Moscow Oblast": ["Moscow", "Khimki", "Podolsk"],
-    "Saint Petersburg Oblast": ["Saint Petersburg", "Pushkin", "Pavlovsk"],
-    "Novosibirsk Oblast": ["Novosibirsk", "Berdsk", "Iskitim"],
-}
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from typing import Iterable, Tuple, List
+
+_DATA_FILE = os.path.join(os.path.dirname(__file__), "russia.json")
+
+
+@lru_cache(maxsize=1)
+def _load_mapping() -> dict[str, list[str]]:
+    """Load region to city mapping from :data:`russia.json`."""
+    with open(_DATA_FILE, "r", encoding="utf-8") as fh:
+        records = json.load(fh)
+
+    mapping: dict[str, list[str]] = {}
+    for row in records:
+        region = row["region"]
+        city = row["city"]
+        mapping.setdefault(region, []).append(city)
+
+    for cities in mapping.values():
+        cities.sort()
+    return mapping
 
 
 def get_regions() -> list[str]:
-    """Return the list of available regions."""
-    return list(REGION_TO_CITIES.keys())
+    """Return the full sorted list of regions."""
+    mapping = _load_mapping()
+    regions = sorted(mapping.keys())
+    return regions
 
 
 def get_cities(region: str) -> list[str]:
-    """Return the cities for the given region or empty list."""
-    return REGION_TO_CITIES.get(region, [])
+    """Return the full sorted list of cities for ``region``."""
+    mapping = _load_mapping()
+    return mapping.get(region, [])
+
+
+def _paginate(items: Iterable[str], page: int, per_page: int) -> Tuple[List[str], bool, bool]:
+    """Return a slice of ``items`` along with paging flags."""
+    items = list(items)
+    start = max(page, 0) * per_page
+    end = start + per_page
+    slice_ = items[start:end]
+    has_prev = page > 0
+    has_next = end < len(items)
+    return slice_, has_prev, has_next
+
+
+def get_regions_page(page: int = 0, per_page: int = 10) -> Tuple[List[str], bool, bool]:
+    """Return a page of regions and navigation info."""
+    return _paginate(get_regions(), page, per_page)
+
+
+def get_cities_page(region: str, page: int = 0, per_page: int = 10) -> Tuple[List[str], bool, bool]:
+    """Return a page of cities for ``region`` and navigation info."""
+    return _paginate(get_cities(region), page, per_page)

--- a/tests/test_weight_handlers.py
+++ b/tests/test_weight_handlers.py
@@ -109,6 +109,7 @@ async def dummy_show_search_results(*args, **kwargs):
 common_stub.get_main_menu = lambda: None
 common_stub.ask_and_store = dummy_ask_and_store
 common_stub.show_search_results = dummy_show_search_results
+common_stub.create_paged_keyboard = lambda *a, **k: None
 sys.modules["handlers.common"] = common_stub
 
 # Import cargo and truck modules manually


### PR DESCRIPTION
## Summary
- use new russia.json dataset to provide regions/cities
- paginate location choices with navigation buttons
- update tests for new helper
- document new feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407a42d7e8832ba230e38b33567df2