### PR TITLE
Remove paged location selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This Telegram bot allows users to register, add cargo and trucks, and search the
 - **Progress bar** when filling long forms.
 - **Weight validation** ensures values are between 1 and 1000 tons.
 - **Inline calendar** for selecting dates when adding or searching cargo and trucks.
+- **Extensive region and city list** loaded from `russia.json` when adding
+  cargo or trucks.
 - **Common commands** `/help` and `/cancel`.
 
 ## Running the bot

--- a/handlers/cargo.py
+++ b/handlers/cargo.py
@@ -8,7 +8,11 @@ from states import BaseStates
 from datetime import datetime
 
 from db import get_connection
-from .common import get_main_menu, ask_and_store, show_search_results
+from .common import (
+    get_main_menu,
+    ask_and_store,
+    show_search_results,
+)
 from calendar_keyboard import generate_calendar
 from utils import (
     parse_date,
@@ -21,7 +25,10 @@ from utils import (
     clear_city_cache,
     validate_weight,
 )
-from locations import get_regions, get_cities
+from locations import (
+    get_regions,
+    get_cities,
+)
 from config import Config
 
 class CargoAddStates(BaseStates):
@@ -68,14 +75,12 @@ async def cmd_start_add_cargo(message: types.Message, state: FSMContext):
 
 
 async def process_region_from(message: types.Message, state: FSMContext):
-    region = message.text.strip()
-    if region not in get_regions():
+    text = message.text.strip()
+    if text not in get_regions():
         await message.answer("Пожалуйста, выбери регион из списка.")
         return
-
-    await state.update_data(region_from=region)
-
-    cities = get_cities(region)
+    await state.update_data(region_from=text)
+    cities = get_cities(text)
     kb = types.ReplyKeyboardMarkup(
         keyboard=[[types.KeyboardButton(text=c)] for c in cities],
         resize_keyboard=True,
@@ -113,14 +118,12 @@ async def process_city_from(message: types.Message, state: FSMContext):
 
 
 async def process_region_to(message: types.Message, state: FSMContext):
-    region = message.text.strip()
-    if region not in get_regions():
+    text = message.text.strip()
+    if text not in get_regions():
         await message.answer("Пожалуйста, выбери регион из списка.")
         return
-
-    await state.update_data(region_to=region)
-
-    cities = get_cities(region)
+    await state.update_data(region_to=text)
+    cities = get_cities(text)
     kb = types.ReplyKeyboardMarkup(
         keyboard=[[types.KeyboardButton(text=c)] for c in cities],
         resize_keyboard=True,

--- a/handlers/truck.py
+++ b/handlers/truck.py
@@ -9,7 +9,11 @@ from states import BaseStates
 from datetime import datetime
 
 from db import get_connection
-from .common import get_main_menu, ask_and_store, show_search_results
+from .common import (
+    get_main_menu,
+    ask_and_store,
+    show_search_results,
+)
 from calendar_keyboard import generate_calendar
 from utils import (
     parse_date,
@@ -22,7 +26,10 @@ from utils import (
     validate_weight,
 )
 from config import Config
-from locations import get_regions, get_cities
+from locations import (
+    get_regions,
+    get_cities,
+)
 
 class TruckAddStates(BaseStates):
     region        = State()
@@ -65,14 +72,13 @@ async def cmd_start_add_truck(message: types.Message, state: FSMContext):
 
 
 async def process_region(message: types.Message, state: FSMContext):
-    region = message.text.strip()
-    if region not in get_regions():
+    text = message.text.strip()
+    if text not in get_regions():
         await message.answer("Пожалуйста, выбери регион из списка.")
         return
 
-    await state.update_data(region=region)
-
-    cities = get_cities(region)
+    await state.update_data(region=text)
+    cities = get_cities(text)
     kb = types.ReplyKeyboardMarkup(
         keyboard=[[KeyboardButton(text=c)] for c in cities],
         resize_keyboard=True,

--- a/locations.py
+++ b/locations.py
@@ -1,17 +1,42 @@
-"""Predefined regions and their cities for user selection."""
+"""Utilities for obtaining Russian regions and cities."""
 
-REGION_TO_CITIES: dict[str, list[str]] = {
-    "Moscow Oblast": ["Moscow", "Khimki", "Podolsk"],
-    "Saint Petersburg Oblast": ["Saint Petersburg", "Pushkin", "Pavlovsk"],
-    "Novosibirsk Oblast": ["Novosibirsk", "Berdsk", "Iskitim"],
-}
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from typing import List
+
+_DATA_FILE = os.path.join(os.path.dirname(__file__), "russia.json")
+
+
+@lru_cache(maxsize=1)
+def _load_mapping() -> dict[str, list[str]]:
+    """Load region to city mapping from :data:`russia.json`."""
+    with open(_DATA_FILE, "r", encoding="utf-8") as fh:
+        records = json.load(fh)
+
+    mapping: dict[str, list[str]] = {}
+    for row in records:
+        region = row["region"]
+        city = row["city"]
+        mapping.setdefault(region, []).append(city)
+
+    for cities in mapping.values():
+        cities.sort()
+    return mapping
 
 
 def get_regions() -> list[str]:
-    """Return the list of available regions."""
-    return list(REGION_TO_CITIES.keys())
+    """Return the full sorted list of regions."""
+    mapping = _load_mapping()
+    regions = sorted(mapping.keys())
+    return regions
 
 
 def get_cities(region: str) -> list[str]:
-    """Return the cities for the given region or empty list."""
-    return REGION_TO_CITIES.get(region, [])
+    """Return the full sorted list of cities for ``region``."""
+    mapping = _load_mapping()
+    return mapping.get(region, [])
+
+


### PR DESCRIPTION
## Summary
- drop navigation arrows for region/city selection
- simplify handlers to display full region and city lists
- remove paging utilities and helper
- update tests and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407a42d7e8832ba230e38b33567df2