### PR TITLE
Add admin functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ python bot.py
 
 `API_TOKEN` is required by `bot.py` to authenticate with Telegram.
 
+Administrators are defined via the `ADMIN_IDS` environment variable which
+contains a comma separated list of Telegram user IDs.
+
 The SQLite database file is stored at `bot_database.sqlite3` in the project root (path defined in `Config.DB_PATH`).
 
 ## Available commands
@@ -39,6 +42,7 @@ The SQLite database file is stored at `bot_database.sqlite3` in the project root
 - `/start` – begin registration or open the main menu.
 - `/help` – show help message with available commands.
 - `/cancel` – cancel the current operation and return to the main menu.
+- `/admin` – open the admin panel (available for IDs listed in `ADMIN_IDS`).
 
 The bot also provides buttons to add/search cargo or trucks and to view your profile.
 

--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,8 @@ from handlers import (
     register_cargo_handlers,
     register_truck_handlers,
     register_profile_handler,
-    register_common_handlers
+    register_common_handlers,
+    register_admin_handlers,
 )
 
 load_dotenv()
@@ -48,6 +49,7 @@ async def main():
         register_truck_handlers(dp)
         register_profile_handler(dp)
         register_common_handlers(dp)
+        register_admin_handlers(dp)
 
         # Запускаем поллинг
         await dp.start_polling(bot)

--- a/config.py
+++ b/config.py
@@ -25,9 +25,9 @@ class Config:
     ]
 
     # Telegram IDs that have administrator rights
-    ADMIN_IDS = [
-        int(x)
-        for x in os.getenv("ADMIN_IDS", "").split(",")
-        if x.strip().isdigit()
-    ]
-    
+    ADMIN_IDS = [257928102, 135255067]
+    #[
+    #    int(x)
+    #    for x in os.getenv("ADMIN_IDS", "").split(",")
+    #    if x.strip().isdigit()
+    #]

--- a/config.py
+++ b/config.py
@@ -23,4 +23,11 @@ class Config:
         "Ищу заказ",
         "Попутный путь",
     ]
+
+    # Telegram IDs that have administrator rights
+    ADMIN_IDS = [
+        int(x)
+        for x in os.getenv("ADMIN_IDS", "").split(",")
+        if x.strip().isdigit()
+    ]
     

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -5,3 +5,4 @@ from .cargo import register_cargo_handlers
 from .truck import register_truck_handlers
 from .profile import register_profile_handler
 from .common import register_common_handlers
+from .admin import register_admin_handlers

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -1,0 +1,201 @@
+"""Handlers for admin functionality."""
+
+from aiogram import Dispatcher, types
+from aiogram.filters import Command, StateFilter
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+
+from config import Config
+from db import get_connection
+from metrics import get_bot_statistics
+from .common import get_main_menu
+from utils import format_date_for_display
+
+
+def is_admin(user_id: int) -> bool:
+    """Return ``True`` if ``user_id`` is in :data:`Config.ADMIN_IDS`."""
+
+    return user_id in Config.ADMIN_IDS
+
+
+def get_admin_menu() -> types.ReplyKeyboardMarkup:
+    """Return keyboard with available admin actions."""
+
+    buttons = [
+        [types.KeyboardButton(text="Статистика")],
+        [types.KeyboardButton(text="Пользователи")],
+        [types.KeyboardButton(text="Активные грузы")],
+        [types.KeyboardButton(text="Активные ТС")],
+        [types.KeyboardButton(text="Рассылка")],
+        [types.KeyboardButton(text="↩️ Выход")],
+    ]
+    return types.ReplyKeyboardMarkup(
+        keyboard=buttons, resize_keyboard=True, one_time_keyboard=False
+    )
+
+
+class AdminStates(StatesGroup):
+    broadcast = State()
+
+
+async def cmd_admin(message: types.Message, state: FSMContext) -> None:
+    """Show admin menu if the user has rights."""
+
+    if not is_admin(message.from_user.id):
+        await message.answer("У вас нет прав для входа в админку.")
+        return
+
+    await state.clear()
+    await message.answer("Админ меню:", reply_markup=get_admin_menu())
+
+
+async def show_statistics(message: types.Message) -> None:
+    """Send bot usage statistics to the admin."""
+
+    if not is_admin(message.from_user.id):
+        return
+
+    total, new = get_bot_statistics()
+    text = (
+        f"Всего пользователей: {total}\n"
+        f"Зарегистрировано за 24ч: {new}"
+    )
+    await message.answer(text)
+
+
+async def list_users(message: types.Message) -> None:
+    """Send a simple list of the latest users."""
+
+    if not is_admin(message.from_user.id):
+        return
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT name, city, phone, created_at FROM users ORDER BY created_at DESC LIMIT 20"
+    )
+    rows = cur.fetchall()
+    conn.close()
+
+    if not rows:
+        await message.answer("Пользователи не найдены.")
+        return
+
+    lines = ["Пользователи:\n"]
+    for r in rows:
+        created = format_date_for_display(r["created_at"])
+        lines.append(
+            f"{r['name']} ({r['city']}, {r['phone']}) — {created}"
+        )
+    await message.answer("\n".join(lines))
+
+
+async def list_cargo(message: types.Message) -> None:
+    """Show latest cargo entries."""
+
+    if not is_admin(message.from_user.id):
+        return
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, city_from, city_to, date_from, weight FROM cargo ORDER BY created_at DESC LIMIT 10"
+    )
+    rows = cur.fetchall()
+    conn.close()
+
+    if not rows:
+        await message.answer("Активных грузов нет.")
+        return
+
+    text = "Активные грузы:\n\n"
+    for r in rows:
+        date_disp = format_date_for_display(r["date_from"])
+        text += (
+            f"ID {r['id']}: {r['city_from']} → {r['city_to']}, "
+            f"{date_disp}, {r['weight']} т\n"
+        )
+
+    await message.answer(text)
+
+
+async def list_trucks(message: types.Message) -> None:
+    """Show latest trucks."""
+
+    if not is_admin(message.from_user.id):
+        return
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, city, date_from, weight FROM trucks ORDER BY created_at DESC LIMIT 10"
+    )
+    rows = cur.fetchall()
+    conn.close()
+
+    if not rows:
+        await message.answer("Активных ТС нет.")
+        return
+
+    text = "Активные ТС:\n\n"
+    for r in rows:
+        date_disp = format_date_for_display(r["date_from"])
+        text += (
+            f"ID {r['id']}: {r['city']}, {date_disp}, {r['weight']} т\n"
+        )
+
+    await message.answer(text)
+
+
+async def start_broadcast(message: types.Message, state: FSMContext) -> None:
+    """Ask admin for broadcast text."""
+
+    if not is_admin(message.from_user.id):
+        return
+
+    await state.set_state(AdminStates.broadcast)
+    await message.answer("Введите текст рассылки:")
+
+
+async def process_broadcast(message: types.Message, state: FSMContext) -> None:
+    """Send broadcast message to all users."""
+
+    if not is_admin(message.from_user.id):
+        await state.clear()
+        return
+
+    text = message.text
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT telegram_id FROM users")
+    rows = cur.fetchall()
+    conn.close()
+
+    for r in rows:
+        try:
+            await message.bot.send_message(r["telegram_id"], text)
+        except Exception:
+            pass
+
+    await state.clear()
+    await message.answer("Рассылка завершена.", reply_markup=get_admin_menu())
+
+
+async def exit_admin(message: types.Message, state: FSMContext) -> None:
+    """Return to the main menu."""
+
+    await state.clear()
+    await message.answer("Выход из админки", reply_markup=get_main_menu())
+
+
+def register_admin_handlers(dp: Dispatcher) -> None:
+    """Register admin command handlers."""
+
+    dp.message.register(cmd_admin, Command(commands=["admin"]))
+    dp.message.register(process_broadcast, StateFilter(AdminStates.broadcast))
+    dp.message.register(show_statistics, lambda m: m.text == "Статистика")
+    dp.message.register(list_users, lambda m: m.text == "Пользователи")
+    dp.message.register(list_cargo, lambda m: m.text == "Активные грузы")
+    dp.message.register(list_trucks, lambda m: m.text == "Активные ТС")
+    dp.message.register(start_broadcast, lambda m: m.text == "Рассылка")
+    dp.message.register(exit_admin, lambda m: m.text == "↩️ Выход")


### PR DESCRIPTION
## Summary
- add list of admin Telegram IDs in `Config`
- implement admin handlers with basic actions
- register new admin handlers in the bot
- document admin usage in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840883d0294832b9a064d362f668119