### PR TITLE
Parse ADMIN_IDS from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+API_TOKEN=YOUR_TELEGRAM_BOT_TOKEN
+# comma separated list of admin user IDs
+ADMIN_IDS=257928102,135255067
+

--- a/README.md
+++ b/README.md
@@ -23,17 +23,26 @@ This Telegram bot allows users to register, add cargo and trucks, and search the
 pip install -r requirements.txt
 ```
 
-2. Export your Telegram bot token as an environment variable and start the bot:
+2. Copy ``.env.example`` to ``.env`` and edit it with your credentials:
 
 ```bash
-export API_TOKEN=<your-telegram-token>
-python bot.py
+cp .env.example .env
+# then open .env and set API_TOKEN and ADMIN_IDS
 ```
 
-`API_TOKEN` is required by `bot.py` to authenticate with Telegram.
+The bot reads ``API_TOKEN`` and ``ADMIN_IDS`` from this file automatically.
 
-Administrators are defined via the `ADMIN_IDS` environment variable which
-contains a comma separated list of Telegram user IDs.
+```
+API_TOKEN=<your-telegram-token>
+ADMIN_IDS=257928102,135255067
+```
+
+Alternatively you may export these variables in the shell before running
+``bot.py``.
+
+```bash
+python bot.py
+```
 
 The SQLite database file is stored at `bot_database.sqlite3` in the project root (path defined in `Config.DB_PATH`).
 

--- a/config.py
+++ b/config.py
@@ -1,6 +1,12 @@
 """Centralized configuration constants for the bot."""
 
 import os
+from dotenv import load_dotenv
+
+# Load variables from a ``.env`` file if present so modules importing
+# :mod:`config` get access to them without manually calling
+# :func:`~dotenv.load_dotenv`.
+load_dotenv()
 
 class Config:
     """Application configuration constants."""
@@ -27,9 +33,8 @@ class Config:
     ]
 
     # Telegram IDs that have administrator rights
-    ADMIN_IDS = [257928102, 135255067]
-    #[
-    #    int(x)
-    #    for x in os.getenv("ADMIN_IDS", "").split(",")
-    #    if x.strip().isdigit()
-    #]
+    ADMIN_IDS = [
+        int(x)
+        for x in os.getenv("ADMIN_IDS", "").split(",")
+        if x.strip().isdigit()
+    ]


### PR DESCRIPTION
## Summary
- read `ADMIN_IDS` from `.env` using `load_dotenv`
- show `.env.example` with example admin IDs
- document using `.env` for `API_TOKEN` and `ADMIN_IDS`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841878acc58832b94af177699107891