### PR TITLE
Refactor calendar callbacks

### DIFF
--- a/handlers/cargo.py
+++ b/handlers/cargo.py
@@ -13,7 +13,7 @@ from .common import (
     ask_and_store,
     show_search_results,
 )
-from calendar_keyboard import generate_calendar
+from calendar_keyboard import generate_calendar, handle_calendar_callback
 from utils import (
     parse_date,
     get_current_user_id,
@@ -235,45 +235,6 @@ async def process_date_to(message: types.Message, state: FSMContext):
         CargoAddStates.weight
     )
     await state.update_data(calendar_field=None)
-
-
-async def process_date_from_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_from selection from the calendar."""
-    date_iso = callback.data.split(":", 1)[1]
-    await state.update_data(date_from=date_iso)
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Дата прибытия:", reply_markup=generate_calendar()
-    )
-    await state.update_data(
-        last_bot_message_id=bot_msg.message_id,
-        calendar_field="date_to",
-    )
-    await state.set_state(CargoAddStates.date_to)
-    await callback.answer()
-
-
-async def process_date_to_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_to selection from the calendar."""
-    date_iso = callback.data.split(":", 1)[1]
-    data = await state.get_data()
-    df_iso = data.get("date_from")
-    dt_from = datetime.strptime(df_iso, "%Y-%m-%d") if df_iso else None
-    dt_to = datetime.strptime(date_iso, "%Y-%m-%d")
-
-    if dt_from and dt_to < dt_from:
-        await callback.answer("Неверная дата", show_alert=True)
-        return
-
-    await state.update_data(date_to=date_iso, calendar_field=None)
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Вес (в тоннах, цифрой):"
-    )
-    await state.update_data(last_bot_message_id=bot_msg.message_id)
-    await state.set_state(CargoAddStates.weight)
-    await callback.answer()
-
 
 async def process_weight(message: types.Message, state: FSMContext):
     """Store cargo weight after validating the user input."""
@@ -614,83 +575,6 @@ async def filter_date_to(message: types.Message, state: FSMContext):
     await state.clear()
 
 
-async def filter_date_from_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_from selection для поиска груза."""
-    if callback.data == "cal:skip":
-        await state.update_data(filter_date_from="нет")
-    else:
-        value = callback.data.split(":", 1)[1]
-        await state.update_data(filter_date_from=value)
-
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Максимальная дата отправления:",
-        reply_markup=generate_calendar(include_skip=True)
-    )
-    await state.update_data(
-        last_bot_message_id=bot_msg.message_id,
-        calendar_field="filter_date_to",
-    )
-    await state.set_state(CargoSearchStates.date_to)
-    await callback.answer()
-
-
-async def filter_date_to_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_to selection для поиска груза и показать результаты."""
-    if callback.data == "cal:skip":
-        await state.update_data(filter_date_to="нет")
-    else:
-        value = callback.data.split(":", 1)[1]
-        await state.update_data(filter_date_to=value)
-
-    data = await state.get_data()
-    user_id = await get_current_user_id(callback.message)
-    fc_from = data.get("filter_city_from", "")
-    fc_to = data.get("filter_city_to", "")
-    fd_from = data.get("filter_date_from", "")
-    fd_to = data.get("filter_date_to", "")
-
-    query = """
-    SELECT c.id, u.name, c.city_from, c.region_from, c.city_to, c.region_to, c.date_from, c.weight, c.body_type
-    FROM cargo c
-    JOIN users u ON c.user_id = u.id
-    WHERE 1=1
-    """
-    params = []
-    if fc_from != "все":
-        query += " AND lower(c.city_from) = ?"
-        params.append(fc_from)
-    if fc_to != "все":
-        query += " AND lower(c.city_to) = ?"
-        params.append(fc_to)
-    if fd_from != "нет":
-        query += " AND date(c.date_from) >= date(?)"
-        params.append(fd_from)
-    if fd_to != "нет":
-        query += " AND date(c.date_from) <= date(?)"
-        params.append(fd_to)
-
-    conn = get_connection()
-    cursor = conn.cursor()
-    cursor.execute(query, tuple(params))
-    rows = cursor.fetchall()
-    conn.close()
-
-    await callback.message.delete()
-    prev_bot_id = data.get("last_bot_message_id")
-    if prev_bot_id:
-        try:
-            await callback.message.chat.delete_message(prev_bot_id)
-        except Exception:
-            pass
-
-    if not rows:
-        await callback.message.answer("📬 По вашему запросу ничего не найдено.", reply_markup=get_main_menu())
-    else:
-        await show_search_results(callback.message, rows)
-
-    log_user_action(user_id, "cargo_search", f"results={len(rows)}")
-    await state.clear()
 
 
 def register_cargo_handlers(dp: Dispatcher):
@@ -703,12 +587,12 @@ def register_cargo_handlers(dp: Dispatcher):
     dp.message.register(process_date_from,   StateFilter(CargoAddStates.date_from))
     dp.message.register(process_date_to,     StateFilter(CargoAddStates.date_to))
     dp.callback_query.register(
-        process_date_from_cb,
+        handle_calendar_callback,
         StateFilter(CargoAddStates.date_from),
         lambda c: c.data.startswith("cal:")
     )
     dp.callback_query.register(
-        process_date_to_cb,
+        handle_calendar_callback,
         StateFilter(CargoAddStates.date_to),
         lambda c: c.data.startswith("cal:")
     )
@@ -724,12 +608,12 @@ def register_cargo_handlers(dp: Dispatcher):
     dp.message.register(filter_date_from,     StateFilter(CargoSearchStates.date_from))
     dp.message.register(filter_date_to,       StateFilter(CargoSearchStates.date_to))
     dp.callback_query.register(
-        filter_date_from_cb,
+        handle_calendar_callback,
         StateFilter(CargoSearchStates.date_from),
         lambda c: c.data.startswith("cal:")
     )
     dp.callback_query.register(
-        filter_date_to_cb,
+        handle_calendar_callback,
         StateFilter(CargoSearchStates.date_to),
         lambda c: c.data.startswith("cal:")
     )

--- a/handlers/truck.py
+++ b/handlers/truck.py
@@ -14,7 +14,7 @@ from .common import (
     ask_and_store,
     show_search_results,
 )
-from calendar_keyboard import generate_calendar
+from calendar_keyboard import generate_calendar, handle_calendar_callback
 from utils import (
     parse_date,
     get_current_user_id,
@@ -177,44 +177,6 @@ async def process_date_to(message: types.Message, state: FSMContext):
         TruckAddStates.weight
     )
     await state.update_data(calendar_field=None)
-
-
-async def process_date_from_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_from selection from calendar."""
-    date_iso = callback.data.split(":", 1)[1]
-    await state.update_data(date_from=date_iso)
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Дата доступности (по):", reply_markup=generate_calendar()
-    )
-    await state.update_data(
-        last_bot_message_id=bot_msg.message_id,
-        calendar_field="date_to",
-    )
-    await state.set_state(TruckAddStates.date_to)
-    await callback.answer()
-
-
-async def process_date_to_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_to selection from calendar."""
-    date_iso = callback.data.split(":", 1)[1]
-    data = await state.get_data()
-    df_iso = data.get("date_from")
-    dt_from = datetime.strptime(df_iso, "%Y-%m-%d") if df_iso else None
-    dt_to = datetime.strptime(date_iso, "%Y-%m-%d")
-    if dt_from and dt_to < dt_from:
-        await callback.answer("Неверная дата", show_alert=True)
-        return
-
-    await state.update_data(date_to=date_iso, calendar_field=None)
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Грузоподъёмность (в тоннах):"
-    )
-    await state.update_data(last_bot_message_id=bot_msg.message_id)
-    await state.set_state(TruckAddStates.weight)
-    await callback.answer()
-
 
 async def process_weight(message: types.Message, state: FSMContext):
     """Store truck weight after validating the input."""
@@ -515,78 +477,6 @@ async def filter_date_to_truck(message: types.Message, state: FSMContext):
     await state.clear()
 
 
-async def filter_date_from_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_from selection for truck search."""
-    if callback.data == "cal:skip":
-        await state.update_data(filter_date_from="нет")
-    else:
-        val = callback.data.split(":", 1)[1]
-        await state.update_data(filter_date_from=val)
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Максимальная дата начала:",
-        reply_markup=generate_calendar(include_skip=True)
-    )
-    await state.update_data(
-        last_bot_message_id=bot_msg.message_id,
-        calendar_field="filter_date_to",
-    )
-    await state.set_state(TruckSearchStates.date_to)
-    await callback.answer()
-
-
-async def filter_date_to_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_to selection for truck search and show results."""
-    if callback.data == "cal:skip":
-        await state.update_data(filter_date_to="нет")
-    else:
-        val = callback.data.split(":", 1)[1]
-        await state.update_data(filter_date_to=val)
-
-    data = await state.get_data()
-    user_id = await get_current_user_id(callback.message)
-    fc = data.get("filter_city", "")
-    fd_from = data.get("filter_date_from", "")
-    fd_to = data.get("filter_date_to", "")
-
-    query = """
-    SELECT t.id, u.name, t.city, t.region, t.date_from, t.weight, t.body_type, t.direction
-    FROM trucks t
-    JOIN users u ON t.user_id = u.id
-    WHERE 1=1
-    """
-    params = []
-    if fc != "все":
-        query += " AND lower(t.city) = ?"
-        params.append(fc)
-    if fd_from != "нет":
-        query += " AND date(t.date_from) >= date(?)"
-        params.append(fd_from)
-    if fd_to != "нет":
-        query += " AND date(t.date_from) <= date(?)"
-        params.append(fd_to)
-
-    conn = get_connection()
-    cursor = conn.cursor()
-    cursor.execute(query, tuple(params))
-    rows = cursor.fetchall()
-    conn.close()
-
-    await callback.message.delete()
-    prev_bot_id = data.get("last_bot_message_id")
-    if prev_bot_id:
-        try:
-            await callback.message.chat.delete_message(prev_bot_id)
-        except Exception:
-            pass
-
-    if not rows:
-        await callback.message.answer("📬 По вашему запросу ТС не найдено.", reply_markup=get_main_menu())
-    else:
-        await show_search_results(callback.message, rows)
-
-    log_user_action(user_id, "truck_search", f"results={len(rows)}")
-    await state.clear()
 
 
 def register_truck_handlers(dp: Dispatcher):
@@ -597,12 +487,12 @@ def register_truck_handlers(dp: Dispatcher):
     dp.message.register(process_date_from,     StateFilter(TruckAddStates.date_from))
     dp.message.register(process_date_to,       StateFilter(TruckAddStates.date_to))
     dp.callback_query.register(
-        process_date_from_cb,
+        handle_calendar_callback,
         StateFilter(TruckAddStates.date_from),
         lambda c: c.data.startswith("cal:")
     )
     dp.callback_query.register(
-        process_date_to_cb,
+        handle_calendar_callback,
         StateFilter(TruckAddStates.date_to),
         lambda c: c.data.startswith("cal:")
     )
@@ -618,12 +508,12 @@ def register_truck_handlers(dp: Dispatcher):
     dp.message.register(filter_date_from_truck,      StateFilter(TruckSearchStates.date_from))
     dp.message.register(filter_date_to_truck,        StateFilter(TruckSearchStates.date_to))
     dp.callback_query.register(
-        filter_date_from_cb,
+        handle_calendar_callback,
         StateFilter(TruckSearchStates.date_from),
         lambda c: c.data.startswith("cal:")
     )
     dp.callback_query.register(
-        filter_date_to_cb,
+        handle_calendar_callback,
         StateFilter(TruckSearchStates.date_to),
         lambda c: c.data.startswith("cal:")
     )


### PR DESCRIPTION
## Summary
- import handle_calendar_callback
- register generic calendar callback handler
- delete bespoke calendar handlers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418c7494fc832b86592fbae8b28f31