### PR TITLE
Add API token check on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ API_TOKEN=<your-telegram-token>
 ADMIN_IDS=257928102,135255067
 ```
 
+The bot will raise an error on startup if ``API_TOKEN`` is not provided.
+
 Alternatively you may export these variables in the shell before running
 ``bot.py``.
 

--- a/bot.py
+++ b/bot.py
@@ -20,6 +20,9 @@ from handlers import (
 
 load_dotenv()
 API_TOKEN = os.getenv("API_TOKEN")
+if not API_TOKEN:
+    logging.error("API_TOKEN environment variable is required")
+    raise RuntimeError("API_TOKEN environment variable is required")
 
 async def main():
     try:


### PR DESCRIPTION
## Summary
- validate `API_TOKEN` after reading environment variables
- document the startup failure when token is missing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ad6ffacc832bb6f685997f5df607