### PR TITLE
Refactor calendar callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This Telegram bot allows users to register, add cargo and trucks, and search the
 - **Truck management**: add a truck and search available trucks.
 - **Profile view** with "📋 Мой профиль" button.
 - **Weight validation** ensures values are between 1 and 1000 tons.
-- **Inline calendar** for selecting dates when adding or searching cargo and trucks.
+- **Inline calendar** with month and year navigation for selecting dates when adding or searching cargo and trucks.
 - **Extensive region and city list** loaded from `russia.json`. When adding
   cargo or trucks the bot shows all regions and cities at once without paging.
 - **Common commands** `/help` and `/cancel`.

--- a/calendar_keyboard.py
+++ b/calendar_keyboard.py
@@ -47,23 +47,23 @@ def generate_calendar(
     rows.append(
         [
             types.InlineKeyboardButton(
-                "\u00ab",
+                text="\u00ab",
                 callback_data=f"cal:prev_y:{year}-{month}",
             ),
             types.InlineKeyboardButton(
-                "<",
+                text="<",
                 callback_data=f"cal:prev_m:{year}-{month}",
             ),
             types.InlineKeyboardButton(
-                f"{MONTHS_RU[month]} {year}",
+                text=f"{MONTHS_RU[month]} {year}",
                 callback_data="ignore",
             ),
             types.InlineKeyboardButton(
-                ">",
+                text=">",
                 callback_data=f"cal:next_m:{year}-{month}",
             ),
             types.InlineKeyboardButton(
-                "\u00bb",
+                text="\u00bb",
                 callback_data=f"cal:next_y:{year}-{month}",
             ),
         ]

--- a/calendar_keyboard.py
+++ b/calendar_keyboard.py
@@ -120,7 +120,7 @@ async def handle_calendar_callback(callback: types.CallbackQuery, state: FSMCont
         data = await state.get_data()
         include_skip = data.get("calendar_include_skip", False)
         markup = generate_calendar(year, month, include_skip=include_skip)
-        await callback.message.edit_reply_markup(markup)
+        await callback.message.edit_reply_markup(reply_markup=markup)
         await callback.answer()
         return
 

--- a/calendar_keyboard.py
+++ b/calendar_keyboard.py
@@ -1,17 +1,80 @@
 """Inline calendar keyboard helpers."""
 
-from datetime import datetime
 import calendar
+from datetime import datetime
+
 from aiogram import types
+from aiogram.fsm.context import FSMContext
+
+from db import get_connection
+from handlers.common import get_main_menu, show_search_results
+from utils import get_current_user_id, log_user_action
+
+MONTHS_RU = [
+    "",
+    "Январь",
+    "Февраль",
+    "Март",
+    "Апрель",
+    "Май",
+    "Июнь",
+    "Июль",
+    "Август",
+    "Сентябрь",
+    "Октябрь",
+    "Ноябрь",
+    "Декабрь",
+]
+
+DAYS_RU = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"]
 
 
-def generate_calendar(include_skip: bool = False) -> types.InlineKeyboardMarkup:
-    """Return a simple calendar for the current month."""
+def generate_calendar(
+    year: int | None = None,
+    month: int | None = None,
+    include_skip: bool = False,
+) -> types.InlineKeyboardMarkup:
+    """Return an inline calendar for the given month."""
+
     now = datetime.now()
-    year, month = now.year, now.month
+    year = year or now.year
+    month = month or now.month
     cal = calendar.monthcalendar(year, month)
 
     rows: list[list[types.InlineKeyboardButton]] = []
+
+    # Navigation row: prev year/month and next year/month
+    rows.append(
+        [
+            types.InlineKeyboardButton(
+                "\u00ab",
+                callback_data=f"cal:prev_y:{year}-{month}",
+            ),
+            types.InlineKeyboardButton(
+                "<",
+                callback_data=f"cal:prev_m:{year}-{month}",
+            ),
+            types.InlineKeyboardButton(
+                f"{MONTHS_RU[month]} {year}",
+                callback_data="ignore",
+            ),
+            types.InlineKeyboardButton(
+                ">",
+                callback_data=f"cal:next_m:{year}-{month}",
+            ),
+            types.InlineKeyboardButton(
+                "\u00bb",
+                callback_data=f"cal:next_y:{year}-{month}",
+            ),
+        ]
+    )
+
+    # Days of week row
+    rows.append(
+        [types.InlineKeyboardButton(text=d, callback_data="ignore") for d in DAYS_RU]
+    )
+
+    # Weeks with day numbers
     for week in cal:
         row = []
         for day in week:
@@ -30,24 +93,247 @@ def generate_calendar(include_skip: bool = False) -> types.InlineKeyboardMarkup:
     return types.InlineKeyboardMarkup(inline_keyboard=rows)
 
 
-async def handle_calendar_callback(callback: types.CallbackQuery, state) -> None:
-    """Process calendar callbacks and ask next question."""
+async def handle_calendar_callback(callback: types.CallbackQuery, state: FSMContext) -> None:
+    """Handle inline calendar selection for all scenarios."""
+    data_str = callback.data
+
+    # Handle calendar navigation buttons
+    if data_str.startswith("cal:prev_") or data_str.startswith("cal:next_"):
+        _, action, ym = data_str.split(":", 2)
+        year, month = map(int, ym.split("-"))
+
+        if action == "prev_m":
+            month -= 1
+            if month < 1:
+                month = 12
+                year -= 1
+        elif action == "next_m":
+            month += 1
+            if month > 12:
+                month = 1
+                year += 1
+        elif action == "prev_y":
+            year -= 1
+        elif action == "next_y":
+            year += 1
+
+        data = await state.get_data()
+        include_skip = data.get("calendar_include_skip", False)
+        markup = generate_calendar(year, month, include_skip=include_skip)
+        await callback.message.edit_reply_markup(markup)
+        await callback.answer()
+        return
+
+    value = "нет" if data_str == "cal:skip" else data_str.split(":", 1)[1]
+    current_state = await state.get_state()
+
+    await callback.message.delete()
+
+    if current_state == "CargoAddStates:date_from":
+        await state.update_data(date_from=value)
+        bot = await callback.message.answer(
+            "Дата прибытия:", reply_markup=generate_calendar()
+        )
+        await state.update_data(
+            last_bot_message_id=bot.message_id,
+            calendar_field="date_to",
+            calendar_include_skip=False,
+        )
+        await state.set_state("CargoAddStates:date_to")
+        await callback.answer()
+        return
+
+    if current_state == "CargoAddStates:date_to":
+        data = await state.get_data()
+        df = data.get("date_from")
+        dt_from = datetime.strptime(df, "%Y-%m-%d") if df else None
+        dt_to = datetime.strptime(value, "%Y-%m-%d")
+        if dt_from and dt_to < dt_from:
+            await callback.answer("Неверная дата", show_alert=True)
+            return
+        await state.update_data(date_to=value, calendar_field=None)
+        bot = await callback.message.answer("Вес (в тоннах, цифрой):")
+        await state.update_data(last_bot_message_id=bot.message_id)
+        await state.set_state("CargoAddStates:weight")
+        await callback.answer()
+        return
+
+    if current_state == "CargoSearchStates:date_from":
+        key = "нет" if callback.data == "cal:skip" else value
+        await state.update_data(filter_date_from=key)
+        bot = await callback.message.answer(
+            "Максимальная дата отправления:",
+            reply_markup=generate_calendar(include_skip=True),
+        )
+        await state.update_data(
+            last_bot_message_id=bot.message_id,
+            calendar_field="filter_date_to",
+            calendar_include_skip=True,
+        )
+        await state.set_state("CargoSearchStates:date_to")
+        await callback.answer()
+        return
+
+    if current_state == "CargoSearchStates:date_to":
+        key = "нет" if callback.data == "cal:skip" else value
+        await state.update_data(filter_date_to=key, calendar_field=None)
+
+        data = await state.get_data()
+        user_id = await get_current_user_id(callback.message)
+        fc_from = data.get("filter_city_from", "")
+        fc_to = data.get("filter_city_to", "")
+        fd_from = data.get("filter_date_from", "")
+        fd_to = data.get("filter_date_to", "")
+
+        query = """
+        SELECT c.id, u.name, c.city_from, c.region_from, c.city_to, c.region_to, c.date_from, c.weight, c.body_type
+        FROM cargo c
+        JOIN users u ON c.user_id = u.id
+        WHERE 1=1
+        """
+        params = []
+        if fc_from != "все":
+            query += " AND lower(c.city_from) = ?"
+            params.append(fc_from)
+        if fc_to != "все":
+            query += " AND lower(c.city_to) = ?"
+            params.append(fc_to)
+        if fd_from != "нет":
+            query += " AND date(c.date_from) >= date(?)"
+            params.append(fd_from)
+        if fd_to != "нет":
+            query += " AND date(c.date_from) <= date(?)"
+            params.append(fd_to)
+
+        conn = get_connection()
+        cursor = conn.cursor()
+        cursor.execute(query, tuple(params))
+        rows = cursor.fetchall()
+        conn.close()
+
+        prev_bot = data.get("last_bot_message_id")
+        if prev_bot:
+            try:
+                await callback.message.chat.delete_message(prev_bot)
+            except Exception:
+                pass
+
+        if not rows:
+            await callback.message.answer("📬 По вашему запросу ничего не найдено.", reply_markup=get_main_menu())
+        else:
+            await show_search_results(callback.message, rows)
+
+        log_user_action(user_id, "cargo_search", f"results={len(rows)}")
+        await state.clear()
+        await callback.answer()
+        return
+
+    if current_state == "TruckAddStates:date_from":
+        await state.update_data(date_from=value)
+        bot = await callback.message.answer(
+            "Дата доступности (по):", reply_markup=generate_calendar()
+        )
+        await state.update_data(
+            last_bot_message_id=bot.message_id,
+            calendar_field="date_to",
+            calendar_include_skip=False,
+        )
+        await state.set_state("TruckAddStates:date_to")
+        await callback.answer()
+        return
+
+    if current_state == "TruckAddStates:date_to":
+        data = await state.get_data()
+        df = data.get("date_from")
+        dt_from = datetime.strptime(df, "%Y-%m-%d") if df else None
+        dt_to = datetime.strptime(value, "%Y-%m-%d")
+        if dt_from and dt_to < dt_from:
+            await callback.answer("Неверная дата", show_alert=True)
+            return
+        await state.update_data(date_to=value, calendar_field=None)
+        bot = await callback.message.answer("Грузоподъёмность (в тоннах):")
+        await state.update_data(last_bot_message_id=bot.message_id)
+        await state.set_state("TruckAddStates:weight")
+        await callback.answer()
+        return
+
+    if current_state == "TruckSearchStates:date_from":
+        key = "нет" if callback.data == "cal:skip" else value
+        await state.update_data(filter_date_from=key)
+        bot = await callback.message.answer(
+            "Максимальная дата начала:",
+            reply_markup=generate_calendar(include_skip=True),
+        )
+        await state.update_data(
+            last_bot_message_id=bot.message_id,
+            calendar_field="filter_date_to",
+            calendar_include_skip=True,
+        )
+        await state.set_state("TruckSearchStates:date_to")
+        await callback.answer()
+        return
+
+    if current_state == "TruckSearchStates:date_to":
+        key = "нет" if callback.data == "cal:skip" else value
+        await state.update_data(filter_date_to=key, calendar_field=None)
+
+        data = await state.get_data()
+        user_id = await get_current_user_id(callback.message)
+        fc = data.get("filter_city", "")
+        fd_from = data.get("filter_date_from", "")
+        fd_to = data.get("filter_date_to", "")
+
+        query = """
+        SELECT t.id, u.name, t.city, t.region, t.date_from, t.weight, t.body_type, t.direction
+        FROM trucks t
+        JOIN users u ON t.user_id = u.id
+        WHERE 1=1
+        """
+        params = []
+        if fc != "все":
+            query += " AND lower(t.city) = ?"
+            params.append(fc)
+        if fd_from != "нет":
+            query += " AND date(t.date_from) >= date(?)"
+            params.append(fd_from)
+        if fd_to != "нет":
+            query += " AND date(t.date_from) <= date(?)"
+            params.append(fd_to)
+
+        conn = get_connection()
+        cursor = conn.cursor()
+        cursor.execute(query, tuple(params))
+        rows = cursor.fetchall()
+        conn.close()
+
+        prev_bot = data.get("last_bot_message_id")
+        if prev_bot:
+            try:
+                await callback.message.chat.delete_message(prev_bot)
+            except Exception:
+                pass
+
+        if not rows:
+            await callback.message.answer("📬 По вашему запросу ТС не найдено.", reply_markup=get_main_menu())
+        else:
+            await show_search_results(callback.message, rows)
+
+        log_user_action(user_id, "truck_search", f"results={len(rows)}")
+        await state.clear()
+        await callback.answer()
+        return
+
+    # Generic fallback for other cases
     data = await state.get_data()
     field = data.get("calendar_field")
     next_state = data.get("calendar_next_state")
     next_text = data.get("calendar_next_text")
     next_markup = data.get("calendar_next_markup")
 
-    if callback.data == "cal:skip":
-        value = "нет"
-    else:
-        value = callback.data.split(":", 1)[1]
-
     if field:
         await state.update_data(**{field: value})
 
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(next_text, reply_markup=next_markup)
-    await state.update_data(last_bot_message_id=bot_msg.message_id)
+    bot = await callback.message.answer(next_text, reply_markup=next_markup)
+    await state.update_data(last_bot_message_id=bot.message_id)
     await state.set_state(next_state)
     await callback.answer()

--- a/handlers/cargo.py
+++ b/handlers/cargo.py
@@ -13,7 +13,7 @@ from .common import (
     ask_and_store,
     show_search_results,
 )
-from calendar_keyboard import generate_calendar
+from calendar_keyboard import generate_calendar, handle_calendar_callback
 from utils import (
     parse_date,
     get_current_user_id,
@@ -184,6 +184,7 @@ async def process_city_to(message: types.Message, state: FSMContext):
         calendar_next_state=CargoAddStates.date_to,
         calendar_next_text="Дата прибытия:",
         calendar_next_markup=generate_calendar(),
+        calendar_include_skip=False,
     )
 
 
@@ -208,6 +209,7 @@ async def process_date_from(message: types.Message, state: FSMContext):
         calendar_next_state=CargoAddStates.weight,
         calendar_next_text="Вес (в тоннах, цифрой):",
         calendar_next_markup=None,
+        calendar_include_skip=False,
     )
 
 
@@ -235,45 +237,6 @@ async def process_date_to(message: types.Message, state: FSMContext):
         CargoAddStates.weight
     )
     await state.update_data(calendar_field=None)
-
-
-async def process_date_from_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_from selection from the calendar."""
-    date_iso = callback.data.split(":", 1)[1]
-    await state.update_data(date_from=date_iso)
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Дата прибытия:", reply_markup=generate_calendar()
-    )
-    await state.update_data(
-        last_bot_message_id=bot_msg.message_id,
-        calendar_field="date_to",
-    )
-    await state.set_state(CargoAddStates.date_to)
-    await callback.answer()
-
-
-async def process_date_to_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_to selection from the calendar."""
-    date_iso = callback.data.split(":", 1)[1]
-    data = await state.get_data()
-    df_iso = data.get("date_from")
-    dt_from = datetime.strptime(df_iso, "%Y-%m-%d") if df_iso else None
-    dt_to = datetime.strptime(date_iso, "%Y-%m-%d")
-
-    if dt_from and dt_to < dt_from:
-        await callback.answer("Неверная дата", show_alert=True)
-        return
-
-    await state.update_data(date_to=date_iso, calendar_field=None)
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Вес (в тоннах, цифрой):"
-    )
-    await state.update_data(last_bot_message_id=bot_msg.message_id)
-    await state.set_state(CargoAddStates.weight)
-    await callback.answer()
-
 
 async def process_weight(message: types.Message, state: FSMContext):
     """Store cargo weight after validating the user input."""
@@ -511,6 +474,7 @@ async def filter_city_to(message: types.Message, state: FSMContext):
         calendar_next_state=CargoSearchStates.date_to,
         calendar_next_text="Максимальная дата отправления:",
         calendar_next_markup=generate_calendar(include_skip=True),
+        calendar_include_skip=True,
     )
     await state.set_state(CargoSearchStates.date_from)
 
@@ -547,6 +511,7 @@ async def filter_date_from(message: types.Message, state: FSMContext):
         calendar_next_state=CargoSearchStates.date_to,
         calendar_next_text="",
         calendar_next_markup=None,
+        calendar_include_skip=True,
     )
     await state.set_state(CargoSearchStates.date_to)
 
@@ -614,83 +579,6 @@ async def filter_date_to(message: types.Message, state: FSMContext):
     await state.clear()
 
 
-async def filter_date_from_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_from selection для поиска груза."""
-    if callback.data == "cal:skip":
-        await state.update_data(filter_date_from="нет")
-    else:
-        value = callback.data.split(":", 1)[1]
-        await state.update_data(filter_date_from=value)
-
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Максимальная дата отправления:",
-        reply_markup=generate_calendar(include_skip=True)
-    )
-    await state.update_data(
-        last_bot_message_id=bot_msg.message_id,
-        calendar_field="filter_date_to",
-    )
-    await state.set_state(CargoSearchStates.date_to)
-    await callback.answer()
-
-
-async def filter_date_to_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_to selection для поиска груза и показать результаты."""
-    if callback.data == "cal:skip":
-        await state.update_data(filter_date_to="нет")
-    else:
-        value = callback.data.split(":", 1)[1]
-        await state.update_data(filter_date_to=value)
-
-    data = await state.get_data()
-    user_id = await get_current_user_id(callback.message)
-    fc_from = data.get("filter_city_from", "")
-    fc_to = data.get("filter_city_to", "")
-    fd_from = data.get("filter_date_from", "")
-    fd_to = data.get("filter_date_to", "")
-
-    query = """
-    SELECT c.id, u.name, c.city_from, c.region_from, c.city_to, c.region_to, c.date_from, c.weight, c.body_type
-    FROM cargo c
-    JOIN users u ON c.user_id = u.id
-    WHERE 1=1
-    """
-    params = []
-    if fc_from != "все":
-        query += " AND lower(c.city_from) = ?"
-        params.append(fc_from)
-    if fc_to != "все":
-        query += " AND lower(c.city_to) = ?"
-        params.append(fc_to)
-    if fd_from != "нет":
-        query += " AND date(c.date_from) >= date(?)"
-        params.append(fd_from)
-    if fd_to != "нет":
-        query += " AND date(c.date_from) <= date(?)"
-        params.append(fd_to)
-
-    conn = get_connection()
-    cursor = conn.cursor()
-    cursor.execute(query, tuple(params))
-    rows = cursor.fetchall()
-    conn.close()
-
-    await callback.message.delete()
-    prev_bot_id = data.get("last_bot_message_id")
-    if prev_bot_id:
-        try:
-            await callback.message.chat.delete_message(prev_bot_id)
-        except Exception:
-            pass
-
-    if not rows:
-        await callback.message.answer("📬 По вашему запросу ничего не найдено.", reply_markup=get_main_menu())
-    else:
-        await show_search_results(callback.message, rows)
-
-    log_user_action(user_id, "cargo_search", f"results={len(rows)}")
-    await state.clear()
 
 
 def register_cargo_handlers(dp: Dispatcher):
@@ -703,12 +591,12 @@ def register_cargo_handlers(dp: Dispatcher):
     dp.message.register(process_date_from,   StateFilter(CargoAddStates.date_from))
     dp.message.register(process_date_to,     StateFilter(CargoAddStates.date_to))
     dp.callback_query.register(
-        process_date_from_cb,
+        handle_calendar_callback,
         StateFilter(CargoAddStates.date_from),
         lambda c: c.data.startswith("cal:")
     )
     dp.callback_query.register(
-        process_date_to_cb,
+        handle_calendar_callback,
         StateFilter(CargoAddStates.date_to),
         lambda c: c.data.startswith("cal:")
     )
@@ -724,12 +612,12 @@ def register_cargo_handlers(dp: Dispatcher):
     dp.message.register(filter_date_from,     StateFilter(CargoSearchStates.date_from))
     dp.message.register(filter_date_to,       StateFilter(CargoSearchStates.date_to))
     dp.callback_query.register(
-        filter_date_from_cb,
+        handle_calendar_callback,
         StateFilter(CargoSearchStates.date_from),
         lambda c: c.data.startswith("cal:")
     )
     dp.callback_query.register(
-        filter_date_to_cb,
+        handle_calendar_callback,
         StateFilter(CargoSearchStates.date_to),
         lambda c: c.data.startswith("cal:")
     )

--- a/handlers/truck.py
+++ b/handlers/truck.py
@@ -14,7 +14,7 @@ from .common import (
     ask_and_store,
     show_search_results,
 )
-from calendar_keyboard import generate_calendar
+from calendar_keyboard import generate_calendar, handle_calendar_callback
 from utils import (
     parse_date,
     get_current_user_id,
@@ -126,6 +126,7 @@ async def process_city(message: types.Message, state: FSMContext):
         calendar_next_state=TruckAddStates.date_to,
         calendar_next_text="Дата доступности (по):",
         calendar_next_markup=generate_calendar(),
+        calendar_include_skip=False,
     )
 
 
@@ -150,6 +151,7 @@ async def process_date_from(message: types.Message, state: FSMContext):
         calendar_next_state=TruckAddStates.weight,
         calendar_next_text="Грузоподъёмность (в тоннах):",
         calendar_next_markup=None,
+        calendar_include_skip=False,
     )
 
 
@@ -177,44 +179,6 @@ async def process_date_to(message: types.Message, state: FSMContext):
         TruckAddStates.weight
     )
     await state.update_data(calendar_field=None)
-
-
-async def process_date_from_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_from selection from calendar."""
-    date_iso = callback.data.split(":", 1)[1]
-    await state.update_data(date_from=date_iso)
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Дата доступности (по):", reply_markup=generate_calendar()
-    )
-    await state.update_data(
-        last_bot_message_id=bot_msg.message_id,
-        calendar_field="date_to",
-    )
-    await state.set_state(TruckAddStates.date_to)
-    await callback.answer()
-
-
-async def process_date_to_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_to selection from calendar."""
-    date_iso = callback.data.split(":", 1)[1]
-    data = await state.get_data()
-    df_iso = data.get("date_from")
-    dt_from = datetime.strptime(df_iso, "%Y-%m-%d") if df_iso else None
-    dt_to = datetime.strptime(date_iso, "%Y-%m-%d")
-    if dt_from and dt_to < dt_from:
-        await callback.answer("Неверная дата", show_alert=True)
-        return
-
-    await state.update_data(date_to=date_iso, calendar_field=None)
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Грузоподъёмность (в тоннах):"
-    )
-    await state.update_data(last_bot_message_id=bot_msg.message_id)
-    await state.set_state(TruckAddStates.weight)
-    await callback.answer()
-
 
 async def process_weight(message: types.Message, state: FSMContext):
     """Store truck weight after validating the input."""
@@ -416,6 +380,7 @@ async def filter_city(message: types.Message, state: FSMContext):
         calendar_next_state=TruckSearchStates.date_to,
         calendar_next_text="Максимальная дата начала:",
         calendar_next_markup=generate_calendar(include_skip=True),
+        calendar_include_skip=True,
     )
     await state.set_state(TruckSearchStates.date_from)
 
@@ -452,6 +417,7 @@ async def filter_date_from_truck(message: types.Message, state: FSMContext):
         calendar_next_state=TruckSearchStates.date_to,
         calendar_next_text="",
         calendar_next_markup=None,
+        calendar_include_skip=True,
     )
     await state.set_state(TruckSearchStates.date_to)
 
@@ -515,78 +481,6 @@ async def filter_date_to_truck(message: types.Message, state: FSMContext):
     await state.clear()
 
 
-async def filter_date_from_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_from selection for truck search."""
-    if callback.data == "cal:skip":
-        await state.update_data(filter_date_from="нет")
-    else:
-        val = callback.data.split(":", 1)[1]
-        await state.update_data(filter_date_from=val)
-    await callback.message.delete()
-    bot_msg = await callback.message.answer(
-        "Максимальная дата начала:",
-        reply_markup=generate_calendar(include_skip=True)
-    )
-    await state.update_data(
-        last_bot_message_id=bot_msg.message_id,
-        calendar_field="filter_date_to",
-    )
-    await state.set_state(TruckSearchStates.date_to)
-    await callback.answer()
-
-
-async def filter_date_to_cb(callback: types.CallbackQuery, state: FSMContext):
-    """Handle date_to selection for truck search and show results."""
-    if callback.data == "cal:skip":
-        await state.update_data(filter_date_to="нет")
-    else:
-        val = callback.data.split(":", 1)[1]
-        await state.update_data(filter_date_to=val)
-
-    data = await state.get_data()
-    user_id = await get_current_user_id(callback.message)
-    fc = data.get("filter_city", "")
-    fd_from = data.get("filter_date_from", "")
-    fd_to = data.get("filter_date_to", "")
-
-    query = """
-    SELECT t.id, u.name, t.city, t.region, t.date_from, t.weight, t.body_type, t.direction
-    FROM trucks t
-    JOIN users u ON t.user_id = u.id
-    WHERE 1=1
-    """
-    params = []
-    if fc != "все":
-        query += " AND lower(t.city) = ?"
-        params.append(fc)
-    if fd_from != "нет":
-        query += " AND date(t.date_from) >= date(?)"
-        params.append(fd_from)
-    if fd_to != "нет":
-        query += " AND date(t.date_from) <= date(?)"
-        params.append(fd_to)
-
-    conn = get_connection()
-    cursor = conn.cursor()
-    cursor.execute(query, tuple(params))
-    rows = cursor.fetchall()
-    conn.close()
-
-    await callback.message.delete()
-    prev_bot_id = data.get("last_bot_message_id")
-    if prev_bot_id:
-        try:
-            await callback.message.chat.delete_message(prev_bot_id)
-        except Exception:
-            pass
-
-    if not rows:
-        await callback.message.answer("📬 По вашему запросу ТС не найдено.", reply_markup=get_main_menu())
-    else:
-        await show_search_results(callback.message, rows)
-
-    log_user_action(user_id, "truck_search", f"results={len(rows)}")
-    await state.clear()
 
 
 def register_truck_handlers(dp: Dispatcher):
@@ -597,12 +491,12 @@ def register_truck_handlers(dp: Dispatcher):
     dp.message.register(process_date_from,     StateFilter(TruckAddStates.date_from))
     dp.message.register(process_date_to,       StateFilter(TruckAddStates.date_to))
     dp.callback_query.register(
-        process_date_from_cb,
+        handle_calendar_callback,
         StateFilter(TruckAddStates.date_from),
         lambda c: c.data.startswith("cal:")
     )
     dp.callback_query.register(
-        process_date_to_cb,
+        handle_calendar_callback,
         StateFilter(TruckAddStates.date_to),
         lambda c: c.data.startswith("cal:")
     )
@@ -618,12 +512,12 @@ def register_truck_handlers(dp: Dispatcher):
     dp.message.register(filter_date_from_truck,      StateFilter(TruckSearchStates.date_from))
     dp.message.register(filter_date_to_truck,        StateFilter(TruckSearchStates.date_to))
     dp.callback_query.register(
-        filter_date_from_cb,
+        handle_calendar_callback,
         StateFilter(TruckSearchStates.date_from),
         lambda c: c.data.startswith("cal:")
     )
     dp.callback_query.register(
-        filter_date_to_cb,
+        handle_calendar_callback,
         StateFilter(TruckSearchStates.date_to),
         lambda c: c.data.startswith("cal:")
     )


### PR DESCRIPTION
## Summary
- import handle_calendar_callback
- register generic calendar callback handler
- delete bespoke calendar handlers
- add navigation to the inline calendar

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68418c7494fc832b86592fbae8b28f31