### PR TITLE
Add inline edit/delete for profile entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Telegram bot allows users to register, add cargo and trucks, and search the
 - **Cargo management**: add new cargo entries and search existing ones.
 - **Truck management**: add a truck and search available trucks.
 - **Profile view** with "📋 Мой профиль" button that lists your cargo and trucks.
+- **Inline editing**: profile entries now include edit and delete buttons.
 - **Weight validation** ensures values are between 1 and 1000 tons.
 - **Inline calendar** with month and year navigation for selecting dates when adding or searching cargo and trucks.
 - **Extensive region and city list** loaded from `russia.json`. When adding
@@ -56,6 +57,7 @@ The SQLite database file is stored at `bot_database.sqlite3` in the project root
 - `/admin` – open the admin panel (available for IDs listed in `ADMIN_IDS`).
 
 The bot also provides buttons to add/search cargo or trucks and to view your profile.
+Use the inline buttons in the profile to edit or delete entries.
 
 ## Running tests
 

--- a/db.py
+++ b/db.py
@@ -103,6 +103,44 @@ def get_trucks_by_user(user_id: int) -> list[sqlite3.Row]:
     return rows
 
 
+def update_cargo_weight(cargo_id: int, weight: int) -> None:
+    """Update ``weight`` for cargo entry with given ``cargo_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE cargo SET weight = ? WHERE id = ?",
+            (weight, cargo_id),
+        )
+        conn.commit()
+
+
+def delete_cargo(cargo_id: int) -> None:
+    """Remove cargo entry identified by ``cargo_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM cargo WHERE id = ?", (cargo_id,))
+        conn.commit()
+
+
+def update_truck_weight(truck_id: int, weight: int) -> None:
+    """Update ``weight`` for truck entry with given ``truck_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE trucks SET weight = ? WHERE id = ?",
+            (weight, truck_id),
+        )
+        conn.commit()
+
+
+def delete_truck(truck_id: int) -> None:
+    """Remove truck entry identified by ``truck_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM trucks WHERE id = ?", (truck_id,))
+        conn.commit()
+
+
 if __name__ == "__main__":
     init_db()
     print("База данных инициализирована в", DB_PATH)

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -36,6 +36,10 @@ async def show_profile(message: types.Message):
     )
 
     cargo_rows = get_cargo_by_user(user["id"])
+    truck_rows = get_trucks_by_user(user["id"])
+
+    kb_rows: list[list[types.InlineKeyboardButton]] = []
+
     if cargo_rows:
         text += "\n📦 Ваши грузы:\n"
         for r in cargo_rows:
@@ -44,15 +48,35 @@ async def show_profile(message: types.Message):
                 f"- {r['city_from']} → {r['city_to']}, {date_disp}, "
                 f"{r['weight']} т\n"
             )
+            kb_rows.append([
+                types.InlineKeyboardButton(
+                    text="✏️ Изменить",
+                    callback_data=f"edit_cargo:{r['id']}",
+                ),
+                types.InlineKeyboardButton(
+                    text="❌ Удалить",
+                    callback_data=f"del_cargo:{r['id']}",
+                ),
+            ])
 
-    truck_rows = get_trucks_by_user(user["id"])
     if truck_rows:
         text += "\n🚛 Ваши ТС:\n"
         for r in truck_rows:
             date_disp = format_date_for_display(r["date_from"])
             text += f"- {r['city']}, {date_disp}, {r['weight']} т\n"
+            kb_rows.append([
+                types.InlineKeyboardButton(
+                    text="✏️ Изменить",
+                    callback_data=f"edit_truck:{r['id']}",
+                ),
+                types.InlineKeyboardButton(
+                    text="❌ Удалить",
+                    callback_data=f"del_truck:{r['id']}",
+                ),
+            ])
 
-    await message.answer(text, parse_mode="HTML", reply_markup=get_main_menu())
+    markup = types.InlineKeyboardMarkup(inline_keyboard=kb_rows) if kb_rows else None
+    await message.answer(text, parse_mode="HTML", reply_markup=markup)
 
 
 def register_profile_handler(dp: Dispatcher):

--- a/states.py
+++ b/states.py
@@ -10,3 +10,15 @@ class BaseStates(StatesGroup):
     def get_all_states(cls) -> list[State]:
         """Return all attributes that are instances of :class:`State`."""
         return [value for value in cls.__dict__.values() if isinstance(value, State)]
+
+
+class CargoEditStates(BaseStates):
+    """FSM states for cargo editing workflow."""
+
+    weight = State()
+
+
+class TruckEditStates(BaseStates):
+    """FSM states for truck editing workflow."""
+
+    weight = State()

--- a/tests/test_edit_delete.py
+++ b/tests/test_edit_delete.py
@@ -1,0 +1,216 @@
+import os
+import sys
+import types
+import sqlite3
+import asyncio
+import tempfile
+
+# Ensure project root on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# aiogram stubs
+aiogram_module = types.ModuleType("aiogram")
+aiogram_types = types.ModuleType("aiogram.types")
+aiogram_filters = types.ModuleType("aiogram.filters")
+aiogram_fsm_context = types.ModuleType("aiogram.fsm.context")
+aiogram_fsm_state = types.ModuleType("aiogram.fsm.state")
+aiogram_module.types = aiogram_types
+aiogram_fsm = types.ModuleType("aiogram.fsm")
+aiogram_fsm.context = aiogram_fsm_context
+aiogram_fsm.state = aiogram_fsm_state
+aiogram_module.fsm = aiogram_fsm
+sys.modules.setdefault("aiogram", aiogram_module)
+sys.modules.setdefault("aiogram.types", aiogram_types)
+sys.modules.setdefault("aiogram.filters", aiogram_filters)
+sys.modules.setdefault("aiogram.fsm.context", aiogram_fsm_context)
+sys.modules.setdefault("aiogram.fsm.state", aiogram_fsm_state)
+
+class _DummyMessage:
+    pass
+
+aiogram_types.Message = _DummyMessage
+
+class KeyboardButton:
+    def __init__(self, text=None, request_contact=None):
+        self.text = text
+        self.request_contact = request_contact
+
+aiogram_types.KeyboardButton = KeyboardButton
+
+class InlineKeyboardButton:
+    def __init__(self, text=None, callback_data=None):
+        self.text = text
+        self.callback_data = callback_data
+
+aiogram_types.InlineKeyboardButton = InlineKeyboardButton
+
+class InlineKeyboardMarkup:
+    def __init__(self, inline_keyboard=None):
+        self.inline_keyboard = inline_keyboard
+
+aiogram_types.InlineKeyboardMarkup = InlineKeyboardMarkup
+
+class ReplyKeyboardMarkup:
+    def __init__(self, *args, **kwargs):
+        pass
+
+aiogram_types.ReplyKeyboardMarkup = ReplyKeyboardMarkup
+aiogram_fsm.InlineKeyboardMarkup = InlineKeyboardMarkup
+
+class CallbackQuery:
+    def __init__(self, data=""):
+        self.data = data
+        self.message = DummyMessage()
+        self.answered = None
+
+    async def answer(self, text=None):
+        self.answered = text
+
+aiogram_types.CallbackQuery = CallbackQuery
+
+class StateFilter:
+    def __init__(self, state):
+        self.state = state
+
+aiogram_filters.StateFilter = StateFilter
+
+class FSMContext:
+    pass
+
+aiogram_fsm_context.FSMContext = FSMContext
+
+class State:
+    pass
+
+class StatesGroup:
+    pass
+
+aiogram_fsm_state.State = State
+aiogram_fsm_state.StatesGroup = StatesGroup
+
+class Dispatcher:
+    class _Message:
+        def register(self, *args, **kwargs):
+            pass
+
+    def __init__(self):
+        self.message = self._Message()
+
+aiogram_module.Dispatcher = Dispatcher
+
+handlers_pkg = types.ModuleType("handlers")
+handlers_pkg.__path__ = []
+sys.modules["handlers"] = handlers_pkg
+
+common_stub = types.ModuleType("handlers.common")
+common_stub.get_main_menu = lambda: None
+common_stub.ask_and_store = lambda *a, **k: None
+common_stub.show_search_results = lambda *a, **k: None
+common_stub.create_paged_keyboard = lambda *a, **k: None
+common_stub.process_weight_step = lambda *a, **k: None
+common_stub.parse_and_store_date = lambda *a, **k: True
+sys.modules["handlers.common"] = common_stub
+
+import importlib.util
+import db
+
+spec = importlib.util.spec_from_file_location(
+    "handlers.cargo",
+    os.path.join(os.path.dirname(__file__), "..", "handlers", "cargo.py"),
+)
+cargo = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cargo)
+
+spec = importlib.util.spec_from_file_location(
+    "handlers.truck",
+    os.path.join(os.path.dirname(__file__), "..", "handlers", "truck.py"),
+)
+truck = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(truck)
+
+class DummyMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.reply = None
+        self.markup = None
+        self.chat = self
+
+    async def answer(self, text, reply_markup=None):
+        self.reply = text
+        self.markup = reply_markup
+
+    async def delete(self):
+        pass
+
+    async def delete_message(self, mid):
+        pass
+
+class DummyCallbackQuery:
+    def __init__(self, data=""):
+        self.data = data
+        self.message = DummyMessage()
+        self.answered = None
+
+    async def answer(self, text=None):
+        self.answered = text
+
+class DummyFSM:
+    def __init__(self):
+        self.state = None
+        self.data = {}
+
+    async def update_data(self, **kwargs):
+        self.data.update(kwargs)
+
+    async def set_state(self, st):
+        self.state = st
+
+    async def get_data(self):
+        return self.data
+
+    async def clear(self):
+        self.state = None
+        self.data.clear()
+
+def setup_temp_db(monkeypatch):
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    monkeypatch.setattr(db, "DB_PATH", tmp.name)
+    db.init_db()
+    return tmp.name
+
+
+def test_edit_and_delete_flows(monkeypatch):
+    db_path = setup_temp_db(monkeypatch)
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO users (telegram_id, name, city, phone, created_at) VALUES (1, 'u', 'c', 'p', '2020-01-01')"
+    )
+    cur.execute(
+        "INSERT INTO cargo (user_id, city_from, region_from, city_to, region_to, date_from, date_to, weight, body_type, is_local, comment, created_at) VALUES (1, 'A', 'AR', 'B', 'BR', '2024-01-01', '2024-01-02', 10, 'Тент', 0, '', '2023-01-01')"
+    )
+    cur.execute(
+        "INSERT INTO trucks (user_id, city, region, date_from, date_to, weight, body_type, direction, route_regions, comment, created_at) VALUES (1, 'X', 'XR', '2024-01-01', '2024-01-02', 20, 'Тент', 'Ищу заказ', '', '', '2023-01-01')"
+    )
+    conn.commit()
+    conn.close()
+
+    state = DummyFSM()
+    cq = DummyCallbackQuery("edit_cargo:1")
+    asyncio.run(cargo.handle_edit_cargo(cq, state))
+    assert state.state == cargo.CargoEditStates.weight
+    msg = DummyMessage("55")
+    asyncio.run(cargo.process_edit_weight(msg, state))
+    conn = sqlite3.connect(db_path)
+    new_w = conn.execute("SELECT weight FROM cargo WHERE id=1").fetchone()[0]
+    conn.close()
+    assert new_w == 55
+    assert state.state is None
+
+    cq = DummyCallbackQuery("del_truck:1")
+    asyncio.run(truck.handle_delete_truck(cq))
+    conn = sqlite3.connect(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM trucks").fetchone()[0]
+    conn.close()
+    assert count == 0


### PR DESCRIPTION
## Summary
- enable updating and deleting cargo/truck records in DB
- support new edit FSM states
- add edit/delete handlers and expose buttons in profile
- document profile editing
- test editing and deletion flows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e8275754832bbf22aadc225959e1