### PR TITLE
Add inline edit/delete for profile entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This Telegram bot allows users to register, add cargo and trucks, and search the
 - **Cargo management**: add new cargo entries and search existing ones.
 - **Truck management**: add a truck and search available trucks.
 - **Profile view** with "📋 Мой профиль" button that lists your cargo and trucks.
-- **Inline editing**: profile entries now include edit and delete buttons.
+- **Inline editing**: the profile shows buttons to edit your info, cargo and trucks.
 - **Weight validation** ensures values are between 1 and 1000 tons.
 - **Inline calendar** with month and year navigation for selecting dates when adding or searching cargo and trucks.
 - **Extensive region and city list** loaded from `russia.json`. When adding
@@ -57,7 +57,7 @@ The SQLite database file is stored at `bot_database.sqlite3` in the project root
 - `/admin` – open the admin panel (available for IDs listed in `ADMIN_IDS`).
 
 The bot also provides buttons to add/search cargo or trucks and to view your profile.
-Use the inline buttons in the profile to edit or delete entries.
+After opening the profile you can choose to edit your personal info, cargo or trucks.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Telegram bot allows users to register, add cargo and trucks, and search the
 - **Cargo management**: add new cargo entries and search existing ones.
 - **Truck management**: add a truck and search available trucks.
 - **Profile view** with "📋 Мой профиль" button that lists your cargo and trucks.
+- **Inline editing**: profile entries now include edit and delete buttons.
 - **Weight validation** ensures values are between 1 and 1000 tons.
 - **Inline calendar** with month and year navigation for selecting dates when adding or searching cargo and trucks.
 - **Extensive region and city list** loaded from `russia.json`. When adding
@@ -56,6 +57,7 @@ The SQLite database file is stored at `bot_database.sqlite3` in the project root
 - `/admin` – open the admin panel (available for IDs listed in `ADMIN_IDS`).
 
 The bot also provides buttons to add/search cargo or trucks and to view your profile.
+Use the inline buttons in the profile to edit or delete entries.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This Telegram bot allows users to register, add cargo and trucks, and search the
 - **Cargo management**: add new cargo entries and search existing ones.
 - **Truck management**: add a truck and search available trucks.
 - **Profile view** with "📋 Мой профиль" button that lists your cargo and trucks.
-- **Inline editing**: the profile shows buttons to edit your info, cargo and trucks.
+- **Inline editing**: the profile shows buttons to edit your info, cargo and trucks. You can modify route, dates and weight for any entry.
 - **Weight validation** ensures values are between 1 and 1000 tons.
 - **Inline calendar** with month and year navigation for selecting dates when adding or searching cargo and trucks.
 - **Extensive region and city list** loaded from `russia.json`. When adding

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This Telegram bot allows users to register, add cargo and trucks, and search the
 - **Cargo management**: add new cargo entries and search existing ones.
 - **Truck management**: add a truck and search available trucks.
 - **Profile view** with "📋 Мой профиль" button that lists your cargo and trucks.
-- **Inline editing**: the profile shows buttons to edit your info, cargo and trucks. You can modify route, dates and weight for any entry.
+- **Inline editing**: the profile shows buttons to edit your info, cargo and trucks. After selecting an entry you can update its route, dates and weight or delete it. Route editing again uses region and city lists and date editing displays the inline calendar.
 - **Weight validation** ensures values are between 1 and 1000 tons.
 - **Inline calendar** with month and year navigation for selecting dates when adding or searching cargo and trucks.
 - **Extensive region and city list** loaded from `russia.json`. When adding

--- a/db.py
+++ b/db.py
@@ -141,6 +141,40 @@ def delete_truck(truck_id: int) -> None:
         conn.commit()
 
 
+def update_user_name(user_id: int, name: str) -> None:
+    """Update ``name`` for user with ``user_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("UPDATE users SET name = ? WHERE id = ?", (name, user_id))
+        conn.commit()
+
+
+def update_user_city(user_id: int, city: str) -> None:
+    """Update ``city`` for user with ``user_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("UPDATE users SET city = ? WHERE id = ?", (city, user_id))
+        conn.commit()
+
+
+def update_user_phone(user_id: int, phone: str) -> None:
+    """Update ``phone`` for user with ``user_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("UPDATE users SET phone = ? WHERE id = ?", (phone, user_id))
+        conn.commit()
+
+
+def delete_user(user_id: int) -> None:
+    """Remove user and associated cargo and trucks."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM cargo WHERE user_id = ?", (user_id,))
+        cursor.execute("DELETE FROM trucks WHERE user_id = ?", (user_id,))
+        cursor.execute("DELETE FROM users WHERE id = ?", (user_id,))
+        conn.commit()
+
+
 if __name__ == "__main__":
     init_db()
     print("База данных инициализирована в", DB_PATH)

--- a/db.py
+++ b/db.py
@@ -103,6 +103,44 @@ def get_trucks_by_user(user_id: int) -> list[sqlite3.Row]:
     return rows
 
 
+def update_cargo_weight(cargo_id: int, weight: int) -> None:
+    """Update ``weight`` for cargo entry with given ``cargo_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE cargo SET weight = ? WHERE id = ?",
+            (weight, cargo_id),
+        )
+        conn.commit()
+
+
+def delete_cargo(cargo_id: int) -> None:
+    """Remove cargo entry identified by ``cargo_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM cargo WHERE id = ?", (cargo_id,))
+        conn.commit()
+
+
+def update_truck_weight(truck_id: int, weight: int) -> None:
+    """Update ``weight`` for truck entry with given ``truck_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE trucks SET weight = ? WHERE id = ?",
+            (weight, truck_id),
+        )
+        conn.commit()
+
+
+def delete_truck(truck_id: int) -> None:
+    """Remove truck entry identified by ``truck_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM trucks WHERE id = ?", (truck_id,))
+        conn.commit()
+
+
 if __name__ == "__main__":
     init_db()
     print("База данных инициализирована в", DB_PATH)

--- a/db.py
+++ b/db.py
@@ -90,6 +90,18 @@ def get_cargo_by_user(user_id: int) -> list[sqlite3.Row]:
     return rows
 
 
+def get_cargo(cargo_id: int) -> sqlite3.Row | None:
+    """Return cargo entry by ID."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM cargo WHERE id = ?",
+            (cargo_id,),
+        )
+        row = cursor.fetchone()
+    return row
+
+
 def get_trucks_by_user(user_id: int) -> list[sqlite3.Row]:
     """Return truck entries owned by ``user_id``."""
     with get_connection() as conn:
@@ -103,6 +115,15 @@ def get_trucks_by_user(user_id: int) -> list[sqlite3.Row]:
     return rows
 
 
+def get_truck(truck_id: int) -> sqlite3.Row | None:
+    """Return truck entry by ID."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM trucks WHERE id = ?", (truck_id,))
+        row = cursor.fetchone()
+    return row
+
+
 def update_cargo_weight(cargo_id: int, weight: int) -> None:
     """Update ``weight`` for cargo entry with given ``cargo_id``."""
     with get_connection() as conn:
@@ -110,6 +131,28 @@ def update_cargo_weight(cargo_id: int, weight: int) -> None:
         cursor.execute(
             "UPDATE cargo SET weight = ? WHERE id = ?",
             (weight, cargo_id),
+        )
+        conn.commit()
+
+
+def update_cargo_route(cargo_id: int, city_from: str, city_to: str) -> None:
+    """Update route cities for cargo entry ``cargo_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE cargo SET city_from = ?, city_to = ? WHERE id = ?",
+            (city_from, city_to, cargo_id),
+        )
+        conn.commit()
+
+
+def update_cargo_dates(cargo_id: int, date_from: str, date_to: str) -> None:
+    """Update dates for cargo entry ``cargo_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE cargo SET date_from = ?, date_to = ? WHERE id = ?",
+            (date_from, date_to, cargo_id),
         )
         conn.commit()
 
@@ -129,6 +172,28 @@ def update_truck_weight(truck_id: int, weight: int) -> None:
         cursor.execute(
             "UPDATE trucks SET weight = ? WHERE id = ?",
             (weight, truck_id),
+        )
+        conn.commit()
+
+
+def update_truck_route(truck_id: int, route_regions: str) -> None:
+    """Update route regions for truck entry ``truck_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE trucks SET route_regions = ? WHERE id = ?",
+            (route_regions, truck_id),
+        )
+        conn.commit()
+
+
+def update_truck_dates(truck_id: int, date_from: str, date_to: str) -> None:
+    """Update dates for truck entry ``truck_id``."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE trucks SET date_from = ?, date_to = ? WHERE id = ?",
+            (date_from, date_to, truck_id),
         )
         conn.commit()
 

--- a/db.py
+++ b/db.py
@@ -135,13 +135,20 @@ def update_cargo_weight(cargo_id: int, weight: int) -> None:
         conn.commit()
 
 
-def update_cargo_route(cargo_id: int, city_from: str, city_to: str) -> None:
-    """Update route cities for cargo entry ``cargo_id``."""
+def update_cargo_route(
+    cargo_id: int,
+    city_from: str,
+    region_from: str,
+    city_to: str,
+    region_to: str,
+) -> None:
+    """Update route cities and regions for cargo entry ``cargo_id``."""
     with get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "UPDATE cargo SET city_from = ?, city_to = ? WHERE id = ?",
-            (city_from, city_to, cargo_id),
+            "UPDATE cargo SET city_from = ?, region_from = ?,"
+            " city_to = ?, region_to = ? WHERE id = ?",
+            (city_from, region_from, city_to, region_to, cargo_id),
         )
         conn.commit()
 
@@ -176,13 +183,13 @@ def update_truck_weight(truck_id: int, weight: int) -> None:
         conn.commit()
 
 
-def update_truck_route(truck_id: int, route_regions: str) -> None:
-    """Update route regions for truck entry ``truck_id``."""
+def update_truck_route(truck_id: int, city: str, region: str) -> None:
+    """Update location city and region for truck entry ``truck_id``."""
     with get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "UPDATE trucks SET route_regions = ? WHERE id = ?",
-            (route_regions, truck_id),
+            "UPDATE trucks SET city = ?, region = ? WHERE id = ?",
+            (city, region, truck_id),
         )
         conn.commit()
 

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -171,11 +171,11 @@ async def show_manage_cargo(callback: types.CallbackQuery):
     for r in cargo_rows:
         date_disp = format_date_for_display(r["date_from"])
         text += (
-            f"- {r['city_from']} → {r['city_to']}, {date_disp}, "
+            f"- ID {r['id']}: {r['city_from']} → {r['city_to']}, {date_disp}, "
             f"{r['weight']} т\n"
         )
         kb.append([
-            types.InlineKeyboardButton(text="✏️ Изменить", callback_data=f"edit_cargo:{r['id']}") ,
+            types.InlineKeyboardButton(text=f"Изменить ID {r['id']}", callback_data=f"edit_cargo:{r['id']}") ,
             types.InlineKeyboardButton(text="❌ Удалить", callback_data=f"del_cargo:{r['id']}") ,
         ])
     markup = types.InlineKeyboardMarkup(inline_keyboard=kb) if kb else None
@@ -196,9 +196,9 @@ async def show_manage_truck(callback: types.CallbackQuery):
     kb: list[list[types.InlineKeyboardButton]] = []
     for r in truck_rows:
         date_disp = format_date_for_display(r["date_from"])
-        text += f"- {r['city']}, {date_disp}, {r['weight']} т\n"
+        text += f"- ID {r['id']}: {r['city']}, {date_disp}, {r['weight']} т\n"
         kb.append([
-            types.InlineKeyboardButton(text="✏️ Изменить", callback_data=f"edit_truck:{r['id']}") ,
+            types.InlineKeyboardButton(text=f"Изменить ID {r['id']}", callback_data=f"edit_truck:{r['id']}") ,
             types.InlineKeyboardButton(text="❌ Удалить", callback_data=f"del_truck:{r['id']}") ,
         ])
     markup = types.InlineKeyboardMarkup(inline_keyboard=kb) if kb else None

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -1,13 +1,20 @@
 """Handlers showing user profile information."""
 
 from aiogram import types, Dispatcher
+from aiogram.filters import StateFilter
+from aiogram.fsm.context import FSMContext
 from db import (
     get_connection,
     get_cargo_by_user,
     get_trucks_by_user,
+    update_user_name,
+    update_user_city,
+    update_user_phone,
+    delete_user,
 )
 from .common import get_main_menu
-from utils import format_date_for_display
+from utils import format_date_for_display, validate_phone
+from states import UserEditStates
 
 
 async def show_profile(message: types.Message):
@@ -38,8 +45,6 @@ async def show_profile(message: types.Message):
     cargo_rows = get_cargo_by_user(user["id"])
     truck_rows = get_trucks_by_user(user["id"])
 
-    kb_rows: list[list[types.InlineKeyboardButton]] = []
-
     if cargo_rows:
         text += "\n📦 Ваши грузы:\n"
         for r in cargo_rows:
@@ -48,36 +53,168 @@ async def show_profile(message: types.Message):
                 f"- {r['city_from']} → {r['city_to']}, {date_disp}, "
                 f"{r['weight']} т\n"
             )
-            kb_rows.append([
-                types.InlineKeyboardButton(
-                    text="✏️ Изменить",
-                    callback_data=f"edit_cargo:{r['id']}",
-                ),
-                types.InlineKeyboardButton(
-                    text="❌ Удалить",
-                    callback_data=f"del_cargo:{r['id']}",
-                ),
-            ])
 
     if truck_rows:
         text += "\n🚛 Ваши ТС:\n"
         for r in truck_rows:
             date_disp = format_date_for_display(r["date_from"])
             text += f"- {r['city']}, {date_disp}, {r['weight']} т\n"
-            kb_rows.append([
-                types.InlineKeyboardButton(
-                    text="✏️ Изменить",
-                    callback_data=f"edit_truck:{r['id']}",
-                ),
-                types.InlineKeyboardButton(
-                    text="❌ Удалить",
-                    callback_data=f"del_truck:{r['id']}",
-                ),
-            ])
 
-    markup = types.InlineKeyboardMarkup(inline_keyboard=kb_rows) if kb_rows else None
+    markup = types.InlineKeyboardMarkup(
+        inline_keyboard=[
+            [types.InlineKeyboardButton(text="Изменить профиль", callback_data="edit_profile")],
+            [types.InlineKeyboardButton(text="Грузы", callback_data="manage_cargo")],
+            [types.InlineKeyboardButton(text="ТС", callback_data="manage_truck")],
+        ]
+    )
     await message.answer(text, parse_mode="HTML", reply_markup=markup)
+
+
+async def handle_profile_menu(callback: types.CallbackQuery):
+    """Show profile editing options."""
+    kb = types.InlineKeyboardMarkup(
+        inline_keyboard=[
+            [types.InlineKeyboardButton(text="Изменить имя", callback_data="edit_name")],
+            [types.InlineKeyboardButton(text="Изменить город", callback_data="edit_city")],
+            [types.InlineKeyboardButton(text="Изменить телефон", callback_data="edit_phone")],
+            [types.InlineKeyboardButton(text="Удалить", callback_data="del_profile")],
+        ]
+    )
+    await callback.message.answer("Что изменить?", reply_markup=kb)
+    await callback.answer()
+
+
+async def start_edit_name(callback: types.CallbackQuery, state: FSMContext):
+    await callback.message.answer("Новое имя:")
+    await state.set_state(UserEditStates.name)
+    await callback.answer()
+
+
+async def start_edit_city(callback: types.CallbackQuery, state: FSMContext):
+    await callback.message.answer("Новый город:")
+    await state.set_state(UserEditStates.city)
+    await callback.answer()
+
+
+async def start_edit_phone(callback: types.CallbackQuery, state: FSMContext):
+    await callback.message.answer("Новый телефон:")
+    await state.set_state(UserEditStates.phone)
+    await callback.answer()
+
+
+async def process_new_name(message: types.Message, state: FSMContext):
+    user_id = message.from_user.id
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM users WHERE telegram_id = ?", (user_id,))
+    row = cursor.fetchone()
+    conn.close()
+    if row:
+        update_user_name(row["id"], message.text.strip())
+    await message.answer("Имя обновлено.", reply_markup=get_main_menu())
+    await state.clear()
+
+
+async def process_new_city(message: types.Message, state: FSMContext):
+    user_id = message.from_user.id
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM users WHERE telegram_id = ?", (user_id,))
+    row = cursor.fetchone()
+    conn.close()
+    if row:
+        update_user_city(row["id"], message.text.strip())
+    await message.answer("Город обновлён.", reply_markup=get_main_menu())
+    await state.clear()
+
+
+async def process_new_phone(message: types.Message, state: FSMContext):
+    phone = message.text.strip()
+    if not validate_phone(phone):
+        await message.answer("Введите телефон в формате +79991234567:")
+        return
+    user_id = message.from_user.id
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM users WHERE telegram_id = ?", (user_id,))
+    row = cursor.fetchone()
+    conn.close()
+    if row:
+        update_user_phone(row["id"], phone)
+    await message.answer("Телефон обновлён.", reply_markup=get_main_menu())
+    await state.clear()
+
+
+async def handle_delete_profile(callback: types.CallbackQuery):
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM users WHERE telegram_id = ?", (callback.from_user.id,))
+    row = cursor.fetchone()
+    conn.close()
+    if row:
+        delete_user(row["id"])
+    await callback.message.answer("Профиль удалён.", reply_markup=get_main_menu())
+    await callback.answer()
+
+
+async def show_manage_cargo(callback: types.CallbackQuery):
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM users WHERE telegram_id = ?", (callback.from_user.id,))
+    row = cursor.fetchone()
+    if not row:
+        await callback.answer()
+        return
+    cargo_rows = get_cargo_by_user(row["id"])
+    text = "\n📦 Ваши грузы:\n"
+    kb: list[list[types.InlineKeyboardButton]] = []
+    for r in cargo_rows:
+        date_disp = format_date_for_display(r["date_from"])
+        text += (
+            f"- {r['city_from']} → {r['city_to']}, {date_disp}, "
+            f"{r['weight']} т\n"
+        )
+        kb.append([
+            types.InlineKeyboardButton(text="✏️ Изменить", callback_data=f"edit_cargo:{r['id']}") ,
+            types.InlineKeyboardButton(text="❌ Удалить", callback_data=f"del_cargo:{r['id']}") ,
+        ])
+    markup = types.InlineKeyboardMarkup(inline_keyboard=kb) if kb else None
+    await callback.message.answer(text, reply_markup=markup)
+    await callback.answer()
+
+
+async def show_manage_truck(callback: types.CallbackQuery):
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM users WHERE telegram_id = ?", (callback.from_user.id,))
+    row = cursor.fetchone()
+    if not row:
+        await callback.answer()
+        return
+    truck_rows = get_trucks_by_user(row["id"])
+    text = "\n🚛 Ваши ТС:\n"
+    kb: list[list[types.InlineKeyboardButton]] = []
+    for r in truck_rows:
+        date_disp = format_date_for_display(r["date_from"])
+        text += f"- {r['city']}, {date_disp}, {r['weight']} т\n"
+        kb.append([
+            types.InlineKeyboardButton(text="✏️ Изменить", callback_data=f"edit_truck:{r['id']}") ,
+            types.InlineKeyboardButton(text="❌ Удалить", callback_data=f"del_truck:{r['id']}") ,
+        ])
+    markup = types.InlineKeyboardMarkup(inline_keyboard=kb) if kb else None
+    await callback.message.answer(text, reply_markup=markup)
+    await callback.answer()
 
 
 def register_profile_handler(dp: Dispatcher):
     dp.message.register(show_profile, lambda m: m.text == "📋 Мой профиль")
+    dp.callback_query.register(handle_profile_menu, lambda c: c.data == "edit_profile")
+    dp.callback_query.register(show_manage_cargo, lambda c: c.data == "manage_cargo")
+    dp.callback_query.register(show_manage_truck, lambda c: c.data == "manage_truck")
+    dp.callback_query.register(start_edit_name, lambda c: c.data == "edit_name")
+    dp.callback_query.register(start_edit_city, lambda c: c.data == "edit_city")
+    dp.callback_query.register(start_edit_phone, lambda c: c.data == "edit_phone")
+    dp.callback_query.register(handle_delete_profile, lambda c: c.data == "del_profile")
+    dp.message.register(process_new_name, StateFilter(UserEditStates.name))
+    dp.message.register(process_new_city, StateFilter(UserEditStates.city))
+    dp.message.register(process_new_phone, StateFilter(UserEditStates.phone))

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -175,8 +175,7 @@ async def show_manage_cargo(callback: types.CallbackQuery):
             f"{r['weight']} т\n"
         )
         kb.append([
-            types.InlineKeyboardButton(text=f"Изменить ID {r['id']}", callback_data=f"edit_cargo:{r['id']}") ,
-            types.InlineKeyboardButton(text="❌ Удалить", callback_data=f"del_cargo:{r['id']}") ,
+            types.InlineKeyboardButton(text=f"Изменить ID {r['id']}", callback_data=f"edit_cargo:{r['id']}")
         ])
     markup = types.InlineKeyboardMarkup(inline_keyboard=kb) if kb else None
     await callback.message.answer(text, reply_markup=markup)
@@ -198,8 +197,7 @@ async def show_manage_truck(callback: types.CallbackQuery):
         date_disp = format_date_for_display(r["date_from"])
         text += f"- ID {r['id']}: {r['city']}, {date_disp}, {r['weight']} т\n"
         kb.append([
-            types.InlineKeyboardButton(text=f"Изменить ID {r['id']}", callback_data=f"edit_truck:{r['id']}") ,
-            types.InlineKeyboardButton(text="❌ Удалить", callback_data=f"del_truck:{r['id']}") ,
+            types.InlineKeyboardButton(text=f"Изменить ID {r['id']}", callback_data=f"edit_truck:{r['id']}")
         ])
     markup = types.InlineKeyboardMarkup(inline_keyboard=kb) if kb else None
     await callback.message.answer(text, reply_markup=markup)

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -36,6 +36,10 @@ async def show_profile(message: types.Message):
     )
 
     cargo_rows = get_cargo_by_user(user["id"])
+    truck_rows = get_trucks_by_user(user["id"])
+
+    kb_rows: list[list[types.InlineKeyboardButton]] = []
+
     if cargo_rows:
         text += "\n📦 Ваши грузы:\n"
         for r in cargo_rows:
@@ -44,15 +48,35 @@ async def show_profile(message: types.Message):
                 f"- {r['city_from']} → {r['city_to']}, {date_disp}, "
                 f"{r['weight']} т\n"
             )
+            kb_rows.append([
+                types.InlineKeyboardButton(
+                    text="✏️ Изменить",
+                    callback_data=f"edit_cargo:{r['id']}",
+                ),
+                types.InlineKeyboardButton(
+                    text="❌ Удалить",
+                    callback_data=f"del_cargo:{r['id']}",
+                ),
+            ])
 
-    truck_rows = get_trucks_by_user(user["id"])
     if truck_rows:
         text += "\n🚛 Ваши ТС:\n"
         for r in truck_rows:
             date_disp = format_date_for_display(r["date_from"])
             text += f"- {r['city']}, {date_disp}, {r['weight']} т\n"
+            kb_rows.append([
+                types.InlineKeyboardButton(
+                    text="✏️ Изменить",
+                    callback_data=f"edit_truck:{r['id']}",
+                ),
+                types.InlineKeyboardButton(
+                    text="❌ Удалить",
+                    callback_data=f"del_truck:{r['id']}",
+                ),
+            ])
 
-    await message.answer(text, parse_mode="HTML", reply_markup=get_main_menu())
+    markup = types.InlineKeyboardMarkup(inline_keyboard=kb_rows) if kb_rows else None
+    await message.answer(text, parse_mode="HTML", reply_markup=markup)
 
 
 def register_profile_handler(dp: Dispatcher):

--- a/handlers/truck.py
+++ b/handlers/truck.py
@@ -11,7 +11,10 @@ from datetime import datetime
 from db import (
     get_connection,
     update_truck_weight,
+    update_truck_route,
+    update_truck_dates,
     delete_truck,
+    get_truck,
 )
 from .common import (
     get_main_menu,
@@ -471,12 +474,52 @@ async def filter_date_to_truck(message: types.Message, state: FSMContext):
 
 # ========== СЦЕНАРИЙ: РЕДАКТИРОВАНИЕ/УДАЛЕНИЕ ТС ==========
 
-async def handle_edit_truck(callback: types.CallbackQuery, state: FSMContext):
-    """Start truck weight editing."""
+async def handle_edit_truck(callback: types.CallbackQuery):
+    """Show edit options for selected truck."""
+    truck_id = int(callback.data.split(":")[1])
+    row = get_truck(truck_id)
+    if not row:
+        await callback.answer()
+        return
+    text = (
+        f"ТС ID {row['id']}\n"
+        f"{row['city']} ({row['region']})\n"
+        f"{format_date_for_display(row['date_from'])} - "
+        f"{format_date_for_display(row['date_to'])}\n"
+        f"Вес: {row['weight']} т"
+    )
+    kb = types.InlineKeyboardMarkup(
+        inline_keyboard=[
+            [types.InlineKeyboardButton(text="Маршрут", callback_data=f"edit_truck_route:{row['id']}")],
+            [types.InlineKeyboardButton(text="Даты", callback_data=f"edit_truck_dates:{row['id']}")],
+            [types.InlineKeyboardButton(text="Вес", callback_data=f"edit_truck_weight:{row['id']}")],
+        ]
+    )
+    await callback.message.answer(text, reply_markup=kb)
+    await callback.answer()
+
+
+async def start_edit_truck_weight(callback: types.CallbackQuery, state: FSMContext):
     truck_id = int(callback.data.split(":")[1])
     await state.update_data(edit_truck_id=truck_id)
     await callback.message.answer("Новый вес (тонны):")
     await state.set_state(TruckEditStates.weight)
+    await callback.answer()
+
+
+async def start_edit_truck_route(callback: types.CallbackQuery, state: FSMContext):
+    truck_id = int(callback.data.split(":")[1])
+    await state.update_data(edit_truck_id=truck_id)
+    await callback.message.answer("Новый маршрут:")
+    await state.set_state(TruckEditStates.route)
+    await callback.answer()
+
+
+async def start_edit_truck_dates(callback: types.CallbackQuery, state: FSMContext):
+    truck_id = int(callback.data.split(":")[1])
+    await state.update_data(edit_truck_id=truck_id)
+    await callback.message.answer("Новая дата отправления (ГГГГ-ММ-ДД):")
+    await state.set_state(TruckEditStates.date_from)
     await callback.answer()
 
 
@@ -492,6 +535,34 @@ async def process_edit_truck_weight(message: types.Message, state: FSMContext):
         update_truck_weight(tid, weight)
         clear_city_cache()
     await message.answer("Запись обновлена.", reply_markup=get_main_menu())
+    await state.clear()
+
+
+async def process_edit_truck_route(message: types.Message, state: FSMContext):
+    """Update truck route."""
+    data = await state.get_data()
+    tid = data.get("edit_truck_id")
+    if tid:
+        update_truck_route(tid, message.text.strip())
+    await message.answer("Маршрут обновлён.", reply_markup=get_main_menu())
+    await state.clear()
+
+
+async def process_edit_truck_date_from(message: types.Message, state: FSMContext):
+    """Store new start date for truck."""
+    await state.update_data(new_date_from=message.text.strip())
+    await message.answer("Новая дата окончания (ГГГГ-ММ-ДД):")
+    await state.set_state(TruckEditStates.date_to)
+
+
+async def process_edit_truck_date_to(message: types.Message, state: FSMContext):
+    """Update truck dates."""
+    data = await state.get_data()
+    tid = data.get("edit_truck_id")
+    df = data.get("new_date_from")
+    if tid and df:
+        update_truck_dates(tid, df, message.text.strip())
+    await message.answer("Даты обновлены.", reply_markup=get_main_menu())
     await state.clear()
 
 
@@ -551,10 +622,34 @@ def register_truck_handlers(dp: Dispatcher):
         lambda c: c.data.startswith("edit_truck:"),
     )
     dp.callback_query.register(
+        start_edit_truck_route,
+        lambda c: c.data.startswith("edit_truck_route:"),
+    )
+    dp.callback_query.register(
+        start_edit_truck_dates,
+        lambda c: c.data.startswith("edit_truck_dates:"),
+    )
+    dp.callback_query.register(
+        start_edit_truck_weight,
+        lambda c: c.data.startswith("edit_truck_weight:"),
+    )
+    dp.callback_query.register(
         handle_delete_truck,
         lambda c: c.data.startswith("del_truck:"),
     )
     dp.message.register(
         process_edit_truck_weight,
         StateFilter(TruckEditStates.weight),
+    )
+    dp.message.register(
+        process_edit_truck_route,
+        StateFilter(TruckEditStates.route),
+    )
+    dp.message.register(
+        process_edit_truck_date_from,
+        StateFilter(TruckEditStates.date_from),
+    )
+    dp.message.register(
+        process_edit_truck_date_to,
+        StateFilter(TruckEditStates.date_to),
     )

--- a/states.py
+++ b/states.py
@@ -22,3 +22,11 @@ class TruckEditStates(BaseStates):
     """FSM states for truck editing workflow."""
 
     weight = State()
+
+
+class UserEditStates(BaseStates):
+    """FSM states for editing user profile details."""
+
+    name = State()
+    city = State()
+    phone = State()

--- a/states.py
+++ b/states.py
@@ -16,8 +16,10 @@ class CargoEditStates(BaseStates):
     """FSM states for cargo editing workflow."""
 
     weight = State()
-    route_from = State()
-    route_to = State()
+    route_region_from = State()
+    route_city_from = State()
+    route_region_to = State()
+    route_city_to = State()
     date_from = State()
     date_to = State()
 
@@ -26,7 +28,8 @@ class TruckEditStates(BaseStates):
     """FSM states for truck editing workflow."""
 
     weight = State()
-    route = State()
+    route_region = State()
+    route_city = State()
     date_from = State()
     date_to = State()
 

--- a/states.py
+++ b/states.py
@@ -16,12 +16,19 @@ class CargoEditStates(BaseStates):
     """FSM states for cargo editing workflow."""
 
     weight = State()
+    route_from = State()
+    route_to = State()
+    date_from = State()
+    date_to = State()
 
 
 class TruckEditStates(BaseStates):
     """FSM states for truck editing workflow."""
 
     weight = State()
+    route = State()
+    date_from = State()
+    date_to = State()
 
 
 class UserEditStates(BaseStates):

--- a/states.py
+++ b/states.py
@@ -10,3 +10,15 @@ class BaseStates(StatesGroup):
     def get_all_states(cls) -> list[State]:
         """Return all attributes that are instances of :class:`State`."""
         return [value for value in cls.__dict__.values() if isinstance(value, State)]
+
+
+class CargoEditStates(BaseStates):
+    """FSM states for cargo editing workflow."""
+
+    weight = State()
+
+
+class TruckEditStates(BaseStates):
+    """FSM states for truck editing workflow."""
+
+    weight = State()

--- a/tests/test_edit_delete.py
+++ b/tests/test_edit_delete.py
@@ -212,24 +212,32 @@ def test_edit_and_delete_flows(monkeypatch):
     state = DummyFSM()
     cq = DummyCallbackQuery("edit_cargo_route:1")
     asyncio.run(cargo.start_edit_cargo_route(cq, state))
-    assert state.state == cargo.CargoEditStates.route_from
-    asyncio.run(cargo.process_edit_route_from(DummyMessage("X"), state))
-    assert state.state == cargo.CargoEditStates.route_to
-    asyncio.run(cargo.process_edit_route_to(DummyMessage("Y"), state))
+    assert state.state == cargo.CargoEditStates.route_region_from
+    asyncio.run(cargo.process_edit_route_region_from(DummyMessage("AR"), state))
+    assert state.state == cargo.CargoEditStates.route_city_from
+    asyncio.run(cargo.process_edit_route_city_from(DummyMessage("X"), state))
+    assert state.state == cargo.CargoEditStates.route_region_to
+    asyncio.run(cargo.process_edit_route_region_to(DummyMessage("BR"), state))
+    assert state.state == cargo.CargoEditStates.route_city_to
+    asyncio.run(cargo.process_edit_route_city_to(DummyMessage("Y"), state))
     conn = sqlite3.connect(db_path)
-    r = conn.execute("SELECT city_from, city_to FROM cargo WHERE id=1").fetchone()
+    r = conn.execute(
+        "SELECT city_from, region_from, city_to, region_to FROM cargo WHERE id=1"
+    ).fetchone()
     conn.close()
-    assert r == ("X", "Y")
+    assert r == ("X", "AR", "Y", "BR")
 
     state = DummyFSM()
     cq = DummyCallbackQuery("edit_truck_route:1")
     asyncio.run(truck.start_edit_truck_route(cq, state))
-    assert state.state == truck.TruckEditStates.route
-    asyncio.run(truck.process_edit_truck_route(DummyMessage("R"), state))
+    assert state.state == truck.TruckEditStates.route_region
+    asyncio.run(truck.process_edit_truck_route_region(DummyMessage("XR"), state))
+    assert state.state == truck.TruckEditStates.route_city
+    asyncio.run(truck.process_edit_truck_route_city(DummyMessage("X"), state))
     conn = sqlite3.connect(db_path)
-    route = conn.execute("SELECT route_regions FROM trucks WHERE id=1").fetchone()[0]
+    loc = conn.execute("SELECT city, region FROM trucks WHERE id=1").fetchone()
     conn.close()
-    assert route == "R"
+    assert loc == ("X", "XR")
 
     state = DummyFSM()
     cq = DummyCallbackQuery("edit_truck_dates:1")

--- a/tests/test_edit_delete.py
+++ b/tests/test_edit_delete.py
@@ -1,0 +1,216 @@
+import os
+import sys
+import types
+import sqlite3
+import asyncio
+import tempfile
+
+# Ensure project root on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# aiogram stubs
+aiogram_module = types.ModuleType("aiogram")
+aiogram_types = types.ModuleType("aiogram.types")
+aiogram_filters = types.ModuleType("aiogram.filters")
+aiogram_fsm_context = types.ModuleType("aiogram.fsm.context")
+aiogram_fsm_state = types.ModuleType("aiogram.fsm.state")
+aiogram_module.types = aiogram_types
+aiogram_fsm = types.ModuleType("aiogram.fsm")
+aiogram_fsm.context = aiogram_fsm_context
+aiogram_fsm.state = aiogram_fsm_state
+aiogram_module.fsm = aiogram_fsm
+sys.modules.setdefault("aiogram", aiogram_module)
+sys.modules.setdefault("aiogram.types", aiogram_types)
+sys.modules.setdefault("aiogram.filters", aiogram_filters)
+sys.modules.setdefault("aiogram.fsm.context", aiogram_fsm_context)
+sys.modules.setdefault("aiogram.fsm.state", aiogram_fsm_state)
+
+class _DummyMessage:
+    pass
+
+aiogram_types.Message = _DummyMessage
+
+class KeyboardButton:
+    def __init__(self, text=None, request_contact=None):
+        self.text = text
+        self.request_contact = request_contact
+
+aiogram_types.KeyboardButton = KeyboardButton
+
+class InlineKeyboardButton:
+    def __init__(self, text=None, callback_data=None):
+        self.text = text
+        self.callback_data = callback_data
+
+aiogram_types.InlineKeyboardButton = InlineKeyboardButton
+
+class InlineKeyboardMarkup:
+    def __init__(self, inline_keyboard=None):
+        self.inline_keyboard = inline_keyboard
+
+aiogram_types.InlineKeyboardMarkup = InlineKeyboardMarkup
+
+class ReplyKeyboardMarkup:
+    def __init__(self, *args, **kwargs):
+        pass
+
+aiogram_types.ReplyKeyboardMarkup = ReplyKeyboardMarkup
+aiogram_fsm.InlineKeyboardMarkup = InlineKeyboardMarkup
+
+class CallbackQuery:
+    def __init__(self, data=""):
+        self.data = data
+        self.message = DummyMessage()
+        self.answered = None
+
+    async def answer(self, text=None):
+        self.answered = text
+
+aiogram_types.CallbackQuery = CallbackQuery
+
+class StateFilter:
+    def __init__(self, state):
+        self.state = state
+
+aiogram_filters.StateFilter = StateFilter
+
+class FSMContext:
+    pass
+
+aiogram_fsm_context.FSMContext = FSMContext
+
+class State:
+    pass
+
+class StatesGroup:
+    pass
+
+aiogram_fsm_state.State = State
+aiogram_fsm_state.StatesGroup = StatesGroup
+
+class Dispatcher:
+    class _Message:
+        def register(self, *args, **kwargs):
+            pass
+
+    def __init__(self):
+        self.message = self._Message()
+
+aiogram_module.Dispatcher = Dispatcher
+
+handlers_pkg = types.ModuleType("handlers")
+handlers_pkg.__path__ = []
+sys.modules["handlers"] = handlers_pkg
+
+common_stub = types.ModuleType("handlers.common")
+common_stub.get_main_menu = lambda: None
+common_stub.ask_and_store = lambda *a, **k: None
+common_stub.show_search_results = lambda *a, **k: None
+common_stub.create_paged_keyboard = lambda *a, **k: None
+common_stub.process_weight_step = lambda *a, **k: None
+common_stub.parse_and_store_date = lambda *a, **k: True
+sys.modules["handlers.common"] = common_stub
+
+import importlib.util
+import db
+
+spec = importlib.util.spec_from_file_location(
+    "handlers.cargo",
+    os.path.join(os.path.dirname(__file__), "..", "handlers", "cargo.py"),
+)
+cargo = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cargo)
+
+spec = importlib.util.spec_from_file_location(
+    "handlers.truck",
+    os.path.join(os.path.dirname(__file__), "..", "handlers", "truck.py"),
+)
+truck = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(truck)
+
+class DummyMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.reply = None
+        self.markup = None
+        self.chat = self
+
+    async def answer(self, text, reply_markup=None):
+        self.reply = text
+        self.markup = reply_markup
+
+    async def delete(self):
+        pass
+
+    async def delete_message(self, mid):
+        pass
+
+class DummyCallbackQuery:
+    def __init__(self, data=""):
+        self.data = data
+        self.message = DummyMessage()
+        self.answered = None
+
+    async def answer(self, text=None):
+        self.answered = text
+
+class DummyFSM:
+    def __init__(self):
+        self.state = None
+        self.data = {}
+
+    async def update_data(self, **kwargs):
+        self.data.update(kwargs)
+
+    async def set_state(self, st):
+        self.state = st
+
+    async def get_data(self):
+        return self.data
+
+    async def clear(self):
+        self.state = None
+        self.data.clear()
+
+def setup_temp_db(monkeypatch):
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    monkeypatch.setattr(db, "DB_PATH", tmp.name)
+    db.init_db()
+    return tmp.name
+
+
+def test_edit_and_delete_flows(monkeypatch):
+    db_path = setup_temp_db(monkeypatch)
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO users (telegram_id, name, city, phone, created_at) VALUES (1, 'u', 'c', 'p', '2020-01-01')"
+    )
+    cur.execute(
+        "INSERT INTO cargo (user_id, city_from, region_from, city_to, region_to, date_from, date_to, weight, body_type, is_local, comment, created_at) VALUES (1, 'A', 'AR', 'B', 'BR', '2024-01-01', '2024-01-02', 10, 'Тент', 0, '', '2023-01-01')"
+    )
+    cur.execute(
+        "INSERT INTO trucks (user_id, city, region, date_from, date_to, weight, body_type, direction, route_regions, comment, created_at) VALUES (1, 'X', 'XR', '2024-01-01', '2024-01-02', 20, 'Тент', 'Ищу заказ', '', '', '2023-01-01')"
+    )
+    conn.commit()
+    conn.close()
+
+    state = DummyFSM()
+    cq = DummyCallbackQuery("edit_cargo:1")
+    asyncio.run(cargo.handle_edit_cargo(cq, state))
+    assert state.state == cargo.CargoEditStates.weight
+    msg = DummyMessage("55")
+    asyncio.run(cargo.process_edit_weight(msg, state))
+    conn = sqlite3.connect(db_path)
+    new_w = conn.execute("SELECT weight FROM cargo WHERE id=1").fetchone()[0]
+    conn.close()
+    assert new_w == 55
+    assert state.state is None
+
+    cq = DummyCallbackQuery("del_truck:1")
+    asyncio.run(truck.handle_delete_truck(cq))
+    conn = sqlite3.connect(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM trucks").fetchone()[0]
+    conn.close()
+    assert count == 0


### PR DESCRIPTION
## Summary
- enable updating and deleting cargo/truck records in DB
- support new edit FSM states
- add edit/delete handlers and expose buttons in profile
- document profile editing
- test editing and deletion flows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e8275754832bbf22aadc225959e1